### PR TITLE
Fix docker compose run for assets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     environment:
       RAILS_ENV: production
       SECRET_KEY_BASE: just-for-local-docker-compose
+      RAILS_SERVE_STATIC_FILES: only-presence-required
       DATABASE_URL: postgresql://postgres@database/laa-assure-hmrc-data
     depends_on:
       - database


### PR DESCRIPTION
## What
Serve static files via docker compose for local build testing

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3834)

Without RAILS_SERVE_STATIC_FILES a production
like config on a local machine will not serve assets
from the /public folder. This is because
production instances expect to run on apache or nginx
(in our case) which will do this by default regardless.

We may not need to add this for an actual hosted environment
therefore, but if so, we can add it simply enough via deployment
pipeline, production config or the Dockerfile itself.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
