### PR TITLE
prevent unsafe dependabot build

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -70,6 +70,7 @@ jobs:
         run: bundle exec rspec
 
   build:
+    if: github.actor != 'dependabot[bot]'
     needs: test
     runs-on: ubuntu-latest
 

--- a/.helm/assure-hmrc-data/templates/_envs.tpl
+++ b/.helm/assure-hmrc-data/templates/_envs.tpl
@@ -51,4 +51,9 @@ env:
       secretKeyRef:
         name: assure-hmrc-data-sentry-output
         key: sentry_dsn
+  - name: TEST_KEY
+    valueFrom:
+      secretKeyRef:
+        name: assure-hmrc-data-application-output
+        key: my_key
 {{- end }}


### PR DESCRIPTION

## What
Prevent builds of dependabot PRs

- Do not build potentially unsafe dependencies
- test key addition via edit command

Building dependencies gives potentially malicious
code access to github action secrets. It is therefore
not recommended by github themselves and disabled by default
(causing builds to fail).

See [blog on dependabot PRs](
https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
