### PR TITLE
[AP-3938] Add UAT deployment

### DIFF
--- a/.github/actions/deploy_branch/action.yml
+++ b/.github/actions/deploy_branch/action.yml
@@ -89,10 +89,7 @@ runs:
           --set image.tag="${GIT_SHA}" \
           --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$identifier" \
           --set ingress.hosts="{$release_host}" \
+          --set branch_builder_database.name=$RELEASE_NAME \
           --values ${VALUES_FILE} \
           --install \
           --wait
-
-          # TODO:
-          # --set database.name="$RELEASE_NAME" \
-          # --set sidekiq.queue_name="$RELEASE_NAME-"

--- a/.github/actions/deploy_branch/action.yml
+++ b/.github/actions/deploy_branch/action.yml
@@ -1,0 +1,98 @@
+name: "Deploy branch"
+description: 'Deploy docker image of branch to namespace with an ingress based on branch name'
+inputs:
+  ecr-url:
+    description: "ECR endpoint url"
+    required: true
+  kube-cert:
+    description: "Kubernetes cluster authentication certificate"
+    required: true
+  kube-token:
+    description: "Kubernetes cluster authentication token"
+    required: true
+  kube-cluster:
+    description: "Kubernetes cluster name"
+    required: true
+  kube-namespace:
+    description: "Kubernetes cluster namespace"
+    required: true
+  app-environment:
+    description: "environment to which the app is being deployed [staging, production, etc]"
+    required: true
+
+outputs:
+  branch-name:
+    description: "Extracted branch name"
+    value: ${{ steps.extract_branch.outputs.branch_name }}
+  release-name:
+    description: "Extracted release name"
+    value: ${{ steps.extract_release.outputs.release_name }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Extract branch name
+      id: extract_branch
+      shell: bash
+      run: |
+        if [ $GITHUB_EVENT_NAME == "pull_request" ]
+        then
+          branch=$GITHUB_HEAD_REF
+        else
+          branch=${GITHUB_REF#refs/heads/}
+        fi
+        echo "branch_name=$branch" >> $GITHUB_OUTPUT
+
+    - name: Extract release name
+      id: extract_release
+      shell: bash
+      run: |
+        branch_name=${{ steps.extract_branch.outputs.branch_name }}
+        truncated_branch=$(echo $branch_name | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+        echo "release_name=${truncated_branch}" >> $GITHUB_OUTPUT
+
+    - name: Authenticate to the cluster
+      shell: bash
+      env:
+        KUBE_CERT: ${{ inputs.kube-cert }}
+        KUBE_TOKEN: ${{ inputs.kube-token }}
+        KUBE_CLUSTER: ${{ inputs.kube-cluster }}
+        KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
+      run: |
+        echo "${KUBE_CERT}" > ca.crt
+        kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+        kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+        kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+        kubectl config use-context ${KUBE_CLUSTER}
+
+    - name: Helm deployment of branch
+      shell: bash
+      env:
+        ECR_URL: ${{ inputs.ecr-url }}
+        GIT_SHA: ${{ github.sha }}
+        KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
+        VALUES_FILE: .helm/assure-hmrc-data/values/${{ inputs.app-environment }}.yaml
+        RELEASE_NAME: ${{ steps.extract_release.outputs.release_name }}
+      run: |
+        ingress_name="assure-hmrc-data"
+        release_host="$RELEASE_NAME-$KUBE_NAMESPACE.cloud-platform.service.justice.gov.uk"
+        identifier="$RELEASE_NAME-$ingress_name-$KUBE_NAMESPACE-green"
+
+        echo "Deploying commit: $GIT_SHA under release name: '$RELEASE_NAME' to '$release_host'..."
+
+        helm upgrade $RELEASE_NAME .helm/assure-hmrc-data \
+          --namespace ${KUBE_NAMESPACE} \
+          --set image.repository="${ECR_URL}" \
+          --set image.tag="${GIT_SHA}" \
+          --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$identifier" \
+          --set ingress.hosts="{$release_host}" \
+          --values ${VALUES_FILE} \
+          --install \
+          --wait
+
+          # TODO:
+          # --set database.name="$RELEASE_NAME" \
+          # --set sidekiq.queue_name="$RELEASE_NAME-"

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -87,6 +87,26 @@ jobs:
           ecr-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
           ecr-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
 
+  deploy-uat:
+    runs-on: ubuntu-latest
+    needs: build
+    environment: uat
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Deploy UAT branch
+        id: deploy_uat_branch
+        uses: ./.github/actions/deploy_branch
+        with:
+          ecr-url: ${{ secrets.ECR_TEAM_REPO_URL }}
+          kube-cert: ${{ secrets.KUBE_UAT_CERT }}
+          kube-token: ${{ secrets.KUBE_UAT_TOKEN }}
+          kube-cluster: ${{ secrets.KUBE_UAT_CLUSTER }}
+          kube-namespace: ${{ secrets.KUBE_UAT_NAMESPACE }}
+          app-environment: uat
+
   deploy-staging:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -97,8 +117,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Deploy
-        id: deploy
+      - name: Deploy staging
+        id: deploy_staging
         uses: ./.github/actions/deploy
         with:
           ecr-url: ${{ secrets.ECR_TEAM_REPO_URL }}

--- a/.helm/assure-hmrc-data/templates/_envs.tpl
+++ b/.helm/assure-hmrc-data/templates/_envs.tpl
@@ -4,16 +4,6 @@ Environment variables for web and worker containers
 */}}
 {{- define "assure-hmrc-data.envs" }}
 env:
-  {{ if .Values.postgresql.enabled }}
-  - name: POSTGRES_USER
-    value: {{ .Values.postgresql.postgresqlUsername }}
-  - name: POSTGRES_PASSWORD
-    value: {{ .Values.postgresql.postgresqlPassword }}
-  - name: POSTGRES_HOST
-    value: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
-  - name: POSTGRES_DATABASE
-    value: {{ .Values.postgresql.postgresqlDatabase }}
-  {{ else }}
   - name: POSTGRES_USER
     valueFrom:
       secretKeyRef:
@@ -29,6 +19,13 @@ env:
       secretKeyRef:
         name: rds-postgresql-instance-output
         key: rds_instance_address
+  {{ if .Values.branch_builder_database.enabled }}
+  - name: POSTGRES_DATABASE
+    valueFrom:
+      secretKeyRef:
+        name: rds-postgresql-instance-output
+        key: database_name
+  {{ else }}
   - name: POSTGRES_DATABASE
     valueFrom:
       secretKeyRef:

--- a/.helm/assure-hmrc-data/templates/_envs.tpl
+++ b/.helm/assure-hmrc-data/templates/_envs.tpl
@@ -21,10 +21,7 @@ env:
         key: rds_instance_address
   {{ if .Values.branch_builder_database.enabled }}
   - name: POSTGRES_DATABASE
-    valueFrom:
-      secretKeyRef:
-        name: rds-postgresql-instance-output
-        key: database_name
+    value: {{ .Values.branch_builder_database.name | quote }}
   {{ else }}
   - name: POSTGRES_DATABASE
     valueFrom:

--- a/.helm/assure-hmrc-data/values/uat.yaml
+++ b/.helm/assure-hmrc-data/values/uat.yaml
@@ -8,7 +8,7 @@
 
 replicaCount: 1
 
-# image keys that need values provided by `helm install/upgrade...`
+# image key values must be set by `helm --set` command
 image:
   repository: null
   tag: null
@@ -33,5 +33,7 @@ resources:
     cpu: 10m
     memory: 125Mi
 
+# database name value must be set by `helm --set` command
 branch_builder_database:
-  enabled: false
+  enabled: true
+  name: null

--- a/.helm/assure-hmrc-data/values/uat.yaml
+++ b/.helm/assure-hmrc-data/values/uat.yaml
@@ -6,7 +6,7 @@
 # DO NOT STORE SECRETS IN HERE!
 #
 
-replicaCount: 2
+replicaCount: 1
 
 # image keys that need values provided by `helm install/upgrade...`
 image:
@@ -17,19 +17,13 @@ service:
   type: ClusterIP
   port: 80
 
+# defaults overridden by branch builder
 ingress:
   className: default
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: "assure-hmrc-data-laa-assure-hmrc-data-staging-green"
+    external-dns.alpha.kubernetes.io/set-identifier: "assure-hmrc-data-laa-assure-hmrc-data-uat-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-  hosts:
-    - laa-assure-hmrc-data-staging.cloud-platform.service.justice.gov.uk
-    - laa-assure-hmrc-data-staging.apps.live.cloud-platform.service.justice.gov.uk
-    - staging.assure-hmrc-data.service.justice.gov.uk
-  tls:
-    - hosts:
-      - staging.assure-hmrc-data.service.justice.gov.uk
-      secretName: assure-hmrc-data-tls-certificate
+  hosts: []
 
 resources:
   limits:


### PR DESCRIPTION
## What
Add UAT deployment

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3938)

Deploy to UAT namespace

## Testing

You can see the named deployments in the UAT namespace as follows
```shell
kubectl get pods -n laa-assure-hmrc-data-uat
```

You can see the current database in use by a UAT branch pod as follows
```
kubectl exec -it <pod name> -- sh
/usr/src/app $ rails c
> ActiveRecord::Base.connection.execute("select current_database()").to_a
=> [{"current_database"=>"ap-3938-add-uat-deployment"}]
```

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
