### PR TITLE
Add test coverage for error controllers

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -7,6 +7,8 @@ unless ENV["NOCOVERAGE"]
     enable_coverage :branch
     refuse_coverage_drop :line, :branch
 
+    add_filter "app/jobs/application_job.rb"
+    add_filter "app/models/application_record.rb"
     add_filter "config/"
     add_filter "spec/"
 

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :page_title, t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('.too_many_requests') %></h1>
+
+    <p class="govuk-body"><%= t('.try_again_later') %></p>
+
+    <p class="govuk-body"><%= t('.error_continues_html', service: t('service.name'), email: t('service.email')) %></p>
+  </div>
+</div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -13,6 +13,11 @@ en:
       web_address_copied: If you pasted the web address, check you copied the entire address.
       web_address_correct_html: 'If the web address is correct or you selected a link or button and you need to speak to someone about this problem, contact the %{service} team: <a class="govuk-link" href="mailto:%{email}">%{email}</a>'
       web_address_incorrect: If you entered a web address, check it is correct.
+    too_many_requests:
+      error_continues_html: 'If you continue to see this error contact the %{service} team: <a class="govuk-link" href="mailto:%{email}">%{email}</a>.'
+      page_title: Sorry, there’s a problem with the service
+      too_many_requests: Sorry, there’s a problem with the service
+      try_again_later: Try again later.
     unprocessable_entity:
       error_continues_html: 'If you continue to see this error contact the %{service} team: <a class="govuk-link" href="mailto:%{email}">%{email}</a>.'
       page_title: Sorry, there’s a problem with the service

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -10,6 +10,6 @@ require "rails_helper"
 #     end
 #   end
 # end
-RSpec.describe PagesHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe PagesHelper, type: :helper do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ErrorsController do
+
+  describe "#not_found" do
+    before { get "/404" }
+
+    it "returns status 404 and page not found content", :aggregate_failures do
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+      expect(response.body).to include("If you entered a web address, check it is correct.")
+      expect(response.body).to match(
+        %r{contact the Assure HMRC data team.*apply-for-civil-legal-aid@digital.justice.gov.uk}
+      )
+    end
+  end
+
+  describe "#unprocessable_entity" do
+    before { get "/422" }
+
+    it "returns status 422 and unprocessable entity content", :aggregate_failures do
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Sorry, there’s a problem with the service")
+      expect(response.body).to include("Try again later.")
+      expect(response.body).to match(
+        %r{contact the Assure HMRC data team.*apply-for-civil-legal-aid@digital.justice.gov.uk}
+      )
+    end
+  end
+
+  describe "#too_many_requests" do
+    before { get "/429" }
+
+    it "returns status 429 and too many request content", :aggregate_failures do
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.body).to include("Sorry, there’s a problem with the service")
+      expect(response.body).to include("Try again later.")
+      expect(response.body).to match(
+        %r{contact the Assure HMRC data team.*apply-for-civil-legal-aid@digital.justice.gov.uk}
+      )
+    end
+  end
+
+  describe "#internal_server_error" do
+    before { get "/500" }
+
+    it "returns status 500 and internal server error content", :aggregate_failures do
+      expect(response).to have_http_status(:internal_server_error)
+      expect(response.body).to include("Sorry, there’s a problem with the service")
+      expect(response.body).to include("Try again later.")
+      expect(response.body).to include("You’ll need to enter it again when the service is available")
+      expect(response.body).to match(
+        %r{If you have any questions, please email us at.*apply-for-civil-legal-aid@digital.justice.gov.uk}
+      )
+    end
+  end
+end

--- a/spec/views/pages/home.html.erb_spec.rb
+++ b/spec/views/pages/home.html.erb_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
 
-RSpec.describe "pages/home.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe "pages/home.html.erb", type: :view do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end


### PR DESCRIPTION
## What
Add test coverage for error controllers

Get to 100% coverage by adding tests and exluding
empty or abstract classes that are not being used 
as yet.

Have also commented out pending tests for now but could delete
entirely.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
