### PR TITLE
add coverage reporting

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -69,6 +69,12 @@ jobs:
       - name: Run tests
         run: bundle exec rspec
 
+      - uses: joshmfrankel/simplecov-check-action@80bff9575301ca82742eac01efb49afbddaee626
+        with:
+          check_job_name: test-coverage
+          minimum_suite_coverage: 100
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## What

Add basic coverage analysis using third party action

Could use codeclimate but this third party action looks
interesting. it is pinned to a sha for security reasons.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
