### PR TITLE
Use resuable authenticate to cluster action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -27,18 +27,12 @@ runs:
       uses: actions/checkout@v3
 
     - name: Authenticate to the cluster
-      shell: bash
-      env:
-        KUBE_CERT: ${{ inputs.kube-cert }}
-        KUBE_TOKEN: ${{ inputs.kube-token }}
-        KUBE_CLUSTER: ${{ inputs.kube-cluster }}
-        KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
-      run: |
-        echo "${KUBE_CERT}" > ca.crt
-        kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
-        kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
-        kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
-        kubectl config use-context ${KUBE_CLUSTER}
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@2aa2676c3cd9876ec7037ee8b3d729d0306cb7c6
+      with:
+        kube-cert: ${{ inputs.kube-cert }}
+        kube-token: ${{ inputs.kube-token }}
+        kube-cluster: ${{ inputs.kube-cluster }}
+        kube-namespace: ${{ inputs.kube-namespace }}
 
     - name: Helm deployment
       shell: bash

--- a/.github/actions/deploy_branch/action.yml
+++ b/.github/actions/deploy_branch/action.yml
@@ -55,18 +55,12 @@ runs:
         echo "release_name=${truncated_branch}" >> $GITHUB_OUTPUT
 
     - name: Authenticate to the cluster
-      shell: bash
-      env:
-        KUBE_CERT: ${{ inputs.kube-cert }}
-        KUBE_TOKEN: ${{ inputs.kube-token }}
-        KUBE_CLUSTER: ${{ inputs.kube-cluster }}
-        KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
-      run: |
-        echo "${KUBE_CERT}" > ca.crt
-        kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
-        kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
-        kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
-        kubectl config use-context ${KUBE_CLUSTER}
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@2aa2676c3cd9876ec7037ee8b3d729d0306cb7c6
+      with:
+        kube-cert: ${{ inputs.kube-cert }}
+        kube-token: ${{ inputs.kube-token }}
+        kube-cluster: ${{ inputs.kube-cluster }}
+        kube-namespace: ${{ inputs.kube-namespace }}
 
     - name: Helm deployment of branch
       shell: bash


### PR DESCRIPTION
## What
Use reusable authenticate to cluster action

Added to [laa-reusable-github-actions](https://github.com/ministryofjustice/laa-reusable-github-actions)

To avoid repetition of logic. We pin it to a specific commit sha for immutability and, to a lesser extent, security (see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions for more)

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
