### PR TITLE
[AP-3842] authenticate using azure ad

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,11 @@
+# ---------------------
+# Azure AD credentials
+# ---------------------
+
+# get "laa-assure-hmrc-data [local]" from Azure AD
+OMNIAUTH_AZURE_CLIENT_ID='TestAzureClientID'
+OMNIAUTH_AZURE_TENANT_ID='TestAzureTenantID'
+
+# create "laa-assure-hmrc-data [your-name]" in Azure AD
+OMNIAUTH_AZURE_CLIENT_SECRET='TestAzureClientSecret'
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,11 @@ inherit_mode:
   merge:
     - Exclude
 
+Layout/LineLength:
+  Enabled: true
+  Exclude:
+    - config/initializers/devise.rb
+
 Style/NumericLiterals:
   Exclude:
     - db/schema.rb

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ ruby "3.2.1"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.4"
 
+gem 'devise'
+
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,43 +3,22 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.1"
 
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
-gem "rails", "~> 7.0.4"
-
-gem 'devise'
-
-# The modern asset pipeline for Rails [https://github.com/rails/propshaft]
-gem "propshaft"
-
-# Use postgresql as the database for Active Record
-gem "pg", "~> 1.4"
-
-# Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 6.1"
-
-# Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
-gem "jsbundling-rails"
-
-# Bundle and process CSS [https://github.com/rails/cssbundling-rails]
-gem "cssbundling-rails"
-
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
-
-# Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
-
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
-
+gem "cssbundling-rails"
+gem 'devise'
+gem 'dotenv-rails'
+gem "govuk-components"
+gem "govuk_design_system_formbuilder"
+gem "jsbundling-rails"
+gem 'omniauth-azure-activedirectory-v2'
+gem "omniauth-rails_csrf_protection"
+gem "pg", "~> 1.4"
+gem "propshaft"
+gem "puma", "~> 6.1"
+gem "rails", "~> 7.0.4"
 gem "sentry-rails"
 gem "sentry-ruby"
+gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -53,14 +32,7 @@ group :development do
   gem "syntax_tree", require: false
   gem "syntax_tree-haml", require: false
   gem "syntax_tree-rbs", require: false
-  # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
-
-  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-  # gem "rack-mini-profiler"
-
-  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
-  # gem "spring"
 end
 
 group :test do
@@ -70,9 +42,6 @@ group :test do
   gem "simplecov", require: false
   gem "webdrivers"
 end
-
-gem "govuk-components"
-gem "govuk_design_system_formbuilder"
 
 group :test, :development do
   gem "erb_lint", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,10 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erb_lint (0.3.1)
       activesupport
       better_html (>= 2.0.1)
@@ -115,6 +119,10 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     govuk-components (3.3.0)
@@ -130,6 +138,7 @@ GEM
       temple (>= 0.8.2)
       thor
       tilt
+    hashie (5.0.0)
     highline (2.1.0)
     html-attributes-utils (0.9.2)
       activesupport (>= 6.1.4.4)
@@ -153,6 +162,7 @@ GEM
     jsbundling-rails (1.1.1)
       railties (>= 6.0.0)
     json (2.6.3)
+    jwt (2.7.0)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -167,6 +177,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.6.1)
+    multi_xml (0.6.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -181,6 +192,25 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.1)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-azure-activedirectory-v2 (2.0.1)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     overcommit (0.60.0)
       childprocess (>= 0.6.3, < 5)
@@ -203,7 +233,9 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.4)
-    rack-test (2.1.0)
+    rack-protection (3.0.5)
+      rack
+    rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4.3)
       actioncable (= 7.0.4.3)
@@ -298,6 +330,7 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.8.1)
       rexml (~> 3.2, >= 3.2.5)
@@ -315,7 +348,10 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
-    syntax_tree (6.1.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
+    syntax_tree (6.0.2)
       prettier_print (>= 1.2.0)
     syntax_tree-haml (4.0.3)
       haml (>= 5.2)
@@ -334,6 +370,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    version_gem (1.1.2)
     view_component (2.74.1)
       activesupport (>= 5.0.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -367,11 +404,14 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  dotenv-rails
   erb_lint
   govuk-components
   govuk_design_system_formbuilder
   i18n-tasks
   jsbundling-rails
+  omniauth-azure-activedirectory-v2
+  omniauth-rails_csrf_protection
   overcommit
   pg (~> 1.4)
   prettier_print

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    bcrypt (3.1.18)
     better_html (2.0.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -98,6 +99,12 @@ GEM
     debug (1.7.1)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    devise (4.9.0)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
     erb_lint (0.3.1)
@@ -174,6 +181,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
+    orm_adapter (0.5.0)
     overcommit (0.60.0)
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)
@@ -232,6 +240,9 @@ GEM
     regexp_parser (2.7.0)
     reline (0.3.2)
       io-console (~> 0.5)
+    responders (3.1.0)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     rexml (3.2.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -327,6 +338,8 @@ GEM
       activesupport (>= 5.0.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -353,6 +366,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  devise
   erb_lint
   govuk-components
   govuk_design_system_formbuilder

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,11 @@
+# frozen_string_literal: true
+
 class PagesController < ApplicationController
+  before_action :authenticate_user!, only: :home
+
+  def landing
+  end
+
   def home
   end
 end

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,4 +1,6 @@
 class StatusController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def status
     checks = {
       database: database_alive?

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,17 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+ def azure_ad
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if @user&.persisted?
+      sign_in_and_redirect @user, event: :authentication
+    else
+      flash[:alert] = @user.errors.full_messages.join("<br>")
+      Rails.logger.error "Couldn't login user: #{@user.errors.inspect}"
+      redirect_back(fallback_location: root_path, allow_other_host: false) # Don't redirect back to Microsoft
+    end
+  end
+
+  def failure
+    redirect_to unauthenticated_root_path
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,19 @@ class User < ApplicationRecord
   # Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
 
-  # devise :omniauthable , omniauth_providers: [:azure_ad]
+  devise :omniauthable , omniauth_providers: [:azure_ad]
+
+  def self.from_omniauth(auth)
+    user = find_by(auth_subject_id: auth.uid) || find_by(email: auth.info.email, provider: auth.provider)
+
+    if user
+      user.update!(auth_subject_id: auth.uid, auth_last_sign_in_at: Time.current)
+    end
+
+    user
+  end
+
+  def full_name
+    "#{first_name} #{last_name}".strip.titleize
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,9 @@
+class User < ApplicationRecord
+  # Include default devise modules.
+  # Common modules are:
+  # :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
+  # Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
+  # devise :omniauthable , omniauth_providers: [:azure_ad]
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,9 +37,10 @@
     <%= govuk_skip_link %>
 
     <%= govuk_header(service_name: t("service.name")) do |header| %>
-      <%= header.navigation_item(text: "Navigation item 1", href: "#", active: true) %>
-      <%= header.navigation_item(text: "Navigation item 2", href: "#") %>
-      <%= header.navigation_item(text: "Navigation item 3", href: "#") %>
+      <% if current_user %>
+        <%= header.navigation_item(text: current_user.full_name, href: user_path(current_user.id), active: true) %>
+        <%= header.navigation_item(text: "Sign out", href: destroy_user_session_path, active: true) %>
+      <% end %>
     <% end %>
 
     <div class="govuk-width-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,6 +44,26 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">
+        <% if flash[:error] %>
+          <div class="govuk-error-summary">
+            <h2 class="govuk-error-summary__title"><%= flash[:error] %></h2>
+          </div>
+        <% end %>
+
+        <% if flash[:alert] %>
+          <%= govuk_notification_banner(
+                title_text: t("generic.important"),
+                text: flash[:alert],
+              ) %>
+        <% end %>
+
+        <% if flash[:notice] %>
+          <%= govuk_notification_banner(
+                title_text: t("generic.important"),
+                text: flash[:notice],
+              ) %>
+        <% end %>
+
         <%= yield %>
       </main>
     </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,25 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">It works! 🎉</h1>
+    <h1 class="govuk-heading-xl">Submissions</h1>
 
     <p class="govuk-body">
-      Your application is ready - so long as this page rendered without any errors you're good to go.
+      This page should show a list of existing submissions...
     </p>
 
-    <%= govuk_summary_list(
-      rows: [
-        { key: { text: "Rails version" }, value: { text:  Rails.version } },
-        { key: { text: "Ruby version" }, value: { text:  RUBY_VERSION } },
-        { key: {
-          text: "GOV.UK Frontend" },
-          value: {
-            text: JSON
-              .parse(File.read(Rails.root.join("package.json")))
-              .dig("dependencies", "govuk-frontend")
-              .tr("^", "")
-          }
-        }
-      ]
-    ) %>
+    <%= govuk_link_to "New submission", '#' %>
   </div>
 </div>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t("service.name") %></h1>
+
+    <p class="govuk-body">
+      Blurb about purpose of app...
+    </p>
+
+    <%= govuk_start_button(text: "Start now", href: user_azure_ad_omniauth_authorize_path, as_button: true) %>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= current_user.full_name %></h1>
+
+    <%= govuk_summary_list(
+      rows: [
+        { key: { text: "First name" }, value: { text: current_user.first_name } },
+        { key: { text: "Last name" }, value: { text: current_user.last_name } },
+        { key: { text: "Email" }, value: { text: current_user.email } },
+      ]
+    ) %>
+  </div>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -157,7 +157,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,6 +273,13 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
+  config.omniauth :azure_ad,
+                  client_id: ENV["OMNIAUTH_AZURE_CLIENT_ID"],
+                  client_secret: ENV["OMNIAUTH_AZURE_CLIENT_SECRET"],
+                  tenant_id: ENV["OMNIAUTH_AZURE_TENANT_ID"],
+                  name: 'azure_ad',
+                  strategy_class: OmniAuth::Strategies::AzureActivedirectoryV2
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
@@ -310,4 +317,6 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
+
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = 'a568446fa1ea6c837549c1653e04d3c1bf2fa92334c1e815916617db8455bdeb89920f59a9a3b2563200fd2e765d3f0883884aece0ce92d7fdb919cc5f6a0428'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'f67308dd95fa1fdd9f22203b88e0cf5410465cef9c8e0f1c018ca9a0dfdc59b15fc17ad7eefd1ae238b521c4367daf3eb7627c92efa978b13bf4e04735a7ef3a'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found respectively`, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  devise_for :users
+
   root to: "pages#home"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,23 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users,
+    controllers: {
+      omniauth_callbacks: 'users/omniauth_callbacks'
+    }
 
-  root to: "pages#home"
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  devise_scope :user do
+    unauthenticated :user do
+      root 'pages#landing', as: :unauthenticated_root
+    end
 
-  # Defines the root path route ("/")
-  # root "articles#index"
+    authenticated :user do
+      root to: 'pages#home', as: :authenticated_root
+    end
+
+    get 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
+  end
+
+  resources :users, only: :show
+
   get "ping", to: "status#ping", format: :json
   get "healthcheck", to: "status#status", format: :json
   get "status", to: "status#ping", format: :json

--- a/db/migrate/20230317120514_enable_pgcrypto.rb
+++ b/db/migrate/20230317120514_enable_pgcrypto.rb
@@ -1,0 +1,5 @@
+class EnablePgcrypto < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20230317122354_enable_citext.rb
+++ b/db/migrate/20230317122354_enable_citext.rb
@@ -1,0 +1,5 @@
+class EnableCitext < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension 'citext'
+  end
+end

--- a/db/migrate/20230317123223_devise_create_users.rb
+++ b/db/migrate/20230317123223_devise_create_users.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users, id: :uuid do |t|
+      t.citext :email, null: false, default: ""
+      t.string :first_name, null: false, default: ""
+      t.string :last_name, null: false, default: ""
+      t.timestamps null: false
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20230317143105_add_omni_auth_columns_to_users.rb
+++ b/db/migrate/20230317143105_add_omni_auth_columns_to_users.rb
@@ -1,0 +1,11 @@
+class AddOmniAuthColumnsToUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_table :users, bulk: true do |t|
+      t.string :provider, null: false
+      t.string :auth_subject_id
+      t.timestamp :auth_last_sign_in_at
+    end
+
+    add_index :users, [:auth_subject_id, :provider], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_17_123223) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_17_143105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -22,6 +22,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_17_123223) do
     t.string "last_name", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider", null: false
+    t.string "auth_subject_id"
+    t.datetime "auth_last_sign_in_at", precision: nil
+    t.index ["auth_subject_id", "provider"], name: "index_users_on_auth_subject_id_and_provider", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_17_120514) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_17_122354) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_17_123223) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.citext "email", default: "", null: false
+    t.string "first_name", default: "", null: false
+    t.string "last_name", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_17_120514) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_17_122354) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,11 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+
+attribute_sets = [
+  { email: 'joel.sugarman@justice.gov.uk', first_name: 'Joel', last_name: 'Sugarman', provider: 'azure_ad' },
+]
+
+attribute_sets.each do |attributes|
+  User.create_or_find_by!(attributes)
+end

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -59,7 +59,6 @@ helm upgrade my-dry-run-version .helm/assure-hmrc-data \
   --set image.repository="<ECR_TEAM_REPO_URL>" \
   --set image.tag="<ECR_TEAM_REPO_NAME:latest>" \
   --values .helm/assure-hmrc-data/values/staging.yaml
-
 ```
 
 ### Upgrade (or install) of chart (in cluster)

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -30,3 +30,37 @@ bin/dev
 yarn build && yarn build:css # first time or when asset changes applied
 bin/rails server
 ```
+
+### Authentication with Azure AD
+
+Retrieve/create local Azure AD secrets for yourself:
+
+- copy `.env.sample` to `.env.development`
+- login to [portal.azure.com](https://portal.azure.com/) using your `justice.gov.uk` account
+- find the "App registration" called `laa-assure-hmrc-data [local]`
+- copy the "Application (client) ID" and set its value as `OMNIAUTH_AZURE_CLIENT_ID` env var
+- copy the "Application (tenant) ID" and set its value as `OMNIAUTH_AZURE_TENANT_ID` env var
+- select "Certificates & secrets" from the sidebar
+- click the "+ New client secret"
+- name it `laa-assure-hmrc-data [my-name]`
+- accept the default expiry
+- click Add to complete
+- copy the value of the new secret to `OMNIAUTH_AZURE_CLIENT_SECRET` env var
+
+To run the app locally using Azure AD for authentication you will need to run the rails server over TLS
+
+### Setup localhost to use self-signed certificate for TLS
+
+see [rails development using self-signed certificate](https://madeintandem.com/blog/rails-local-development-https-using-self-signed-ssl-certificate/)
+
+```sh
+# create dir to store them, anywhere
+mkdir ~/.ssl/
+
+# generate self-signed cert and key, output to the dir created
+# you will be asked a load of questions but can leave them blank
+openssl req -x509 -sha256 -nodes -newkey rsa:2048 -days 365 -keyout ~/.ssl/localhost.key -out ~/.ssl/localhost.crt
+
+# run rails server using the self-signed certificate
+rails s -b "ssl://localhost:3000?key=$HOME/.ssl/localhost.key&cert=$HOME/.ssl/localhost.crt"
+```

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it { is_expected.to respond_to(:email, :first_name, :last_name) }
+
+  describe '#email' do
+    let(:email) { 'Jo.Example@example.com' }
+    let(:user) { described_class.create!(email:) }
+
+    before { user }
+
+    it 'preserves the case it was created with' do
+      expect(user.email).to eq email
+    end
+
+    it 'is case insensitive when queried' do
+      query_email = email.dup.downcase
+      expect(described_class.find_by(email: query_email).email).to eq email
+    end
+
+    it 'has case insensitive uniqueness enforced by the db' do
+      expect { described_class.create!(email: email.downcase) }.to(
+        raise_error(ActiveRecord::RecordNotUnique,
+                    /Key \(email\)=\(jo.example@example.com\) already exists/)
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What
Spike authentication using omniauth using MoJ Azure AD provider

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3842)

Provide transparent authentication using the MoJ Azure AD tenant but without
the ability to create new users.

This is not intended to be a true omniauth implementation but rather to handoff
authentication to the mechanism used by the intended users (MoJ/DOM1 Azure AD
implementation). 

We MUST not allow:
1. user creation
2. other omniauth provider access (e.g. google), at least for now


TODO:

- [ ] handle non-existent user errors
- [ ] system tests
- [ ] link in header?!
- [ ] translations
- [ ] logout when portal logout?
- [ ] retrieve secrets into env vars - for helm release/deploy


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
