### PR TITLE
AP-3842: add AR encryption secrets keys

### DIFF
--- a/.helm/assure-hmrc-data/templates/_envs.tpl
+++ b/.helm/assure-hmrc-data/templates/_envs.tpl
@@ -45,4 +45,19 @@ env:
       secretKeyRef:
         name: assure-hmrc-data-application-output
         key: sentry_dsn
+  - name: AR_ENCRYPTION_PRIMARY_KEY
+    valueFrom:
+      secretKeyRef:
+        name: assure-hmrc-data-application-output
+        key: ar_encryption_primary_key
+  - name: AR_ENCRYPTION_DETERMINISTIC_KEY
+    valueFrom:
+      secretKeyRef:
+        name: assure-hmrc-data-application-output
+        key: ar_encryption_deterministic_key
+  - name: AR_ENCRYPTION_KEY_DERIVATION_SALT
+    valueFrom:
+      secretKeyRef:
+        name: assure-hmrc-data-application-output
+        key: ar_encryption_key_derivation_salt
 {{- end }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ inherit_mode:
   merge:
     - Exclude
 
+Layout/LineLength:
+  Exclude:
+    - config/*.rb
+
 Style/NumericLiterals:
   Exclude:
     - db/schema.rb

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,10 @@ module LaaAssureHmrcData
     config.x.status.build_date = ENV.fetch("APP_BUILD_DATE", "Not Available")
     config.x.status.build_tag = ENV.fetch("APP_BUILD_TAG", "Not Available")
     config.x.status.git_commit = ENV.fetch("APP_GIT_COMMIT", "Not Available")
+
+    # ActiveRecord::Encryption keys generated with `bin/rails db:encryption:init`
+    config.active_record.encryption.primary_key = ENV.fetch("AR_ENCRYPTION_PRIMARY_KEY", "fake-primary-key")
+    config.active_record.encryption.deterministic_key = ENV.fetch("AR_ENCRYPTION_DETERMINISTIC_KEY", "fake-deterministic-key")
+    config.active_record.encryption.key_derivation_salt = ENV.fetch("AR_ENCRYPTION_KEY_DERIVATION_SALT", "fake-key-derivation-salt")
   end
 end


### PR DESCRIPTION

## What
Add Active Record encryption config and secrets

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3842)

Setup up active record encryption secrets so we
can encrypt user.auth_subject_id. This is used to
authenticate against azure ad.

we may also want encrypt email address at some point
for similar reasons.

NOTE: I have added k8s secrets to all environments now. different for each

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
