### PR TITLE
Bump rack-test 2.0.2 to 2.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
       rack (>= 2.1.0)
     rack-protection (3.0.5)
       rack
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4.3)
       actioncable (= 7.0.4.3)


### PR DESCRIPTION


## What
Bump rack-test 2.0.2 to 2.1.0

This came out of a snyk PR supposedly
related to [SNYK-RUBY-RACK-1061917](https://security.snyk.io/vuln/SNYK-RUBY-RACK-1061917)


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
