### PR TITLE
Add unmet peer dependency postcss@^8.4.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "app",
   "private": "true",
   "dependencies": {
-    "esbuild": "^0.17.18",
     "dropzone": "^6.0.0-beta.2",
+    "esbuild": "^0.17.18",
     "govuk-frontend": "4.6.0",
     "sass": "^1.62.1"
   },
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@prettier/plugin-ruby": "^3.2.2",
     "prettier": "^2.8.8",
+    "postcss": "^8.4.19",
     "standard": "^17.0.0",
     "stylelint": "^14.16.1",
     "stylelint-config-gds": "^0.3.0",


### PR DESCRIPTION
## What
Add `postcss@^8.4.19` dev dependency

handle build warning
```
warning "stylelint-config-gds > stylelint-config-standard-scss > stylelint-config-recommended-scss > postcss-scss@4.0.6" has unmet peer dependency "postcss@^8.4.19".
```

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
