### PR TITLE
AP-4056: Add hmrc interface client

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,13 +12,20 @@ OMNIAUTH_AZURE_REDIRECT_URI=
 # create "laa-assure-hmrc-data [your-name]" in Azure AD
 OMNIAUTH_AZURE_CLIENT_SECRET='TestAzureClientSecret'
 
-# LAA HMRC Interface
-HMRC_INTERFACE_HOST='TestHMRCInterfaceURL'
-HMRC_INTERFACE_UID='TestHMRCInterfaceUID'
-HMRC_INTERFACE_SECRET='TestHMRCInterfaceSecret'
-
 MOCK_AZURE=false
 MOCK_AZURE_PASSWORD='password'
 
+# --------------------------
+# Sidekiq credentials
+# --------------------------
+
 SIDEKIQ_WEB_UI_USERNAME='username'
 SIDEKIQ_WEB_UI_PASSWORD='password'
+
+# --------------------------
+# HMRC Interface credentials
+# --------------------------
+
+HMRC_INTERFACE_HOST='https://fake-laa-hmrc-interface-env'
+HMRC_INTERFACE_UID='TestHMRCInterfaceUID'
+HMRC_INTERFACE_SECRET='TestHMRCInterfaceSecret'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'dotenv-rails'
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "jsbundling-rails"
+gem "oauth2"
 gem 'omniauth_openid_connect'
 gem "omniauth-rails_csrf_protection"
 gem "pg", "~> 1.5"
@@ -54,4 +55,5 @@ group :test, :development do
   gem "overcommit"
   gem "rspec"
   gem "rspec-rails"
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
     childprocess (4.1.0)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.1.2)
       railties (>= 6.0.0)
@@ -170,6 +172,7 @@ GEM
       temple (>= 0.8.2)
       thor
       tilt
+    hashdiff (1.0.1)
     hashie (5.0.0)
     highline (2.1.0)
     html-attributes-utils (1.0.0)
@@ -201,6 +204,7 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
+    jwt (2.7.0)
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -215,6 +219,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.7.0)
+    multi_xml (0.6.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -231,6 +236,13 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
     omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -415,6 +427,9 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     swd (2.0.2)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -445,6 +460,7 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
+    version_gem (1.1.2)
     view_component (3.0.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -464,6 +480,10 @@ GEM
       activesupport
       faraday (~> 2.0)
       faraday-follow_redirects
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -491,6 +511,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   i18n-tasks
   jsbundling-rails
+  oauth2
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   overcommit
@@ -516,6 +537,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  webmock
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,11 +51,6 @@ module LaaAssureHmrcData
     config.active_record.encryption.deterministic_key = ENV.fetch("AR_ENCRYPTION_DETERMINISTIC_KEY", "fake-deterministic-key")
     config.active_record.encryption.key_derivation_salt = ENV.fetch("AR_ENCRYPTION_KEY_DERIVATION_SALT", "fake-key-derivation-salt")
 
-    # HMRC interface api connection details
-    config.x.hmrc_interface.host = ENV.fetch("HMRC_INTERFACE_HOST", nil)
-    config.x.hmrc_interface.client_id = ENV.fetch("HMRC_INTERFACE_UID", nil)
-    config.x.hmrc_interface.client_secret = ENV.fetch("HMRC_INTERFACE_SECRET", nil)
-
     config.x.mock_azure = ENV.fetch("MOCK_AZURE", "false")=="true"
     config.x.mock_azure_password = ENV.fetch("MOCK_AZURE_PASSWORD", nil)
   end

--- a/config/initializers/hmrc_interface.rb
+++ b/config/initializers/hmrc_interface.rb
@@ -1,0 +1,8 @@
+require 'hmrc_interface'
+
+HmrcInterface.configure do |config|
+  config.client_id = ENV.fetch("HMRC_INTERFACE_UID", nil)
+  config.client_secret = ENV.fetch("HMRC_INTERFACE_SECRET", nil)
+  config.host = ENV.fetch("HMRC_INTERFACE_HOST", nil)
+end
+

--- a/lib/hmrc_interface.rb
+++ b/lib/hmrc_interface.rb
@@ -1,0 +1,26 @@
+require 'hmrc_interface/configuration'
+require 'hmrc_interface/client'
+
+module HmrcInterface
+  class << self
+    def client
+      Client.new
+    end
+
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+    alias_method :config, :configuration
+
+    def configure
+      yield(configuration) if block_given?
+      configuration
+    end
+
+    def reset
+      @configuration = Configuration.new
+    end
+  end
+end

--- a/lib/hmrc_interface/client.rb
+++ b/lib/hmrc_interface/client.rb
@@ -1,0 +1,39 @@
+require 'forwardable'
+
+module HmrcInterface
+  class Client
+    extend Forwardable
+    def_delegator HmrcInterface, :configuration
+
+    def initialize
+      oauth_client
+    end
+
+    def bearer_token
+      configuration.test_mode? ? fake_bearer_token : access_token.token
+    end
+
+    def access_token
+      @access_token = new_access_token if @access_token.nil? || @access_token.expired?
+      @access_token
+    end
+
+private
+
+    def oauth_client
+      @oauth_client ||= ::OAuth2::Client.new(
+        configuration.client_id,
+        configuration.client_secret,
+        site: configuration.host,
+      )
+    end
+
+    def new_access_token
+      oauth_client.client_credentials.get_token
+    end
+
+    def fake_bearer_token
+      "fake-hmrc-interface-bearer-token"
+    end
+  end
+end

--- a/lib/hmrc_interface/configuration.rb
+++ b/lib/hmrc_interface/configuration.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module HmrcInterface
+  class Configuration
+    VERSION = '0.0.1'
+
+    attr_accessor :client_id,
+                  :client_secret,
+                  :host,
+                  :test_mode
+
+    attr_reader :headers
+
+    def initialize
+      @headers = user_agent_header
+    end
+
+    def headers=(headers)
+      @headers.merge!(headers)
+    end
+
+    def test_mode?
+      test_mode.to_s == "true"
+    end
+
+    private
+
+    def user_agent_header
+      { 'User-Agent' => "laa-hmrc-interface-client/#{VERSION}" }
+    end
+  end
+end

--- a/spec/lib/hmrc_interface/client_spec.rb
+++ b/spec/lib/hmrc_interface/client_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe HmrcInterface::Client do
+  subject(:client) { described_class.new }
+
+  before do
+    allow(HmrcInterface.configuration)
+      .to receive(:host)
+      .and_return("https://fake-laa-hmrc-interface.service.justice.gov.uk")
+
+    stub_request(:post, %r{(http|https).*laa-hmrc-interface.*/oauth/token})
+      .to_return(
+        status: 200,
+        body: '{"access_token":"test-bearer-token","token_type":"Bearer","expires_in":7200,"created_at":1582809000}',
+        headers: { "Content-Type" => "application/json; charset=utf-8" },
+      )
+  end
+
+  it { is_expected.to respond_to :access_token, :bearer_token }
+
+  describe "#access_token", :stub_oauth_token do
+    subject(:access_token) { client.access_token }
+
+    it { is_expected.to be_an ::OAuth2::AccessToken }
+    it { is_expected.to respond_to :token }
+    it { is_expected.to respond_to :expired? }
+    it { expect(access_token.token).to eql "test-bearer-token" }
+
+    it "sends custom user agent in header" do
+      access_token
+      expect(
+        a_request(:post, "https://fake-laa-hmrc-interface.service.justice.gov.uk/oauth/token")
+      ).to have_been_made
+    end
+
+    context "when retrieving a new token" do
+      let(:oauth_client) { instance_double(::OAuth2::Client, client_credentials:) }
+      let(:client_credentials) { instance_double(::OAuth2::Strategy::ClientCredentials, get_token: new_token) }
+      let(:new_token) { instance_double(::OAuth2::AccessToken, token: 'new-fake-token') }
+
+      before do
+        client.instance_variable_set(:@oauth_client, oauth_client)
+        allow(oauth_client).to receive(:client_credentials).and_return(client_credentials)
+      end
+
+      context "when token nil?" do
+        before do
+          client.instance_variable_set(:@access_token, nil)
+        end
+
+        it "retrieves new access_token using client_credentials grant type" do
+          expect(access_token).to eq(new_token)
+          expect(oauth_client).to have_received(:client_credentials)
+          expect(client_credentials).to have_received(:get_token)
+        end
+      end
+
+      context "when token expired?" do
+        let(:old_token) { instance_double(::OAuth2::AccessToken, token: 'old-fake-token', expired?: true) }
+
+        before do
+          client.instance_variable_set(:@access_token, old_token)
+        end
+
+        it "retrieves new access_token using client_credentials grant type" do
+          expect(access_token).to eq(new_token)
+          expect(oauth_client).to have_received(:client_credentials)
+          expect(client_credentials).to have_received(:get_token)
+        end
+      end
+    end
+  end
+
+  describe "#bearer_token" do
+    subject(:bearer_token) { client.bearer_token }
+
+    context "when test_mode not set" do
+      before { allow(HmrcInterface.configuration).to receive(:test_mode?).and_return(nil) }
+
+      it "sends custom user agent in header" do
+        bearer_token
+        expect(
+          a_request(:post, "https://fake-laa-hmrc-interface.service.justice.gov.uk/oauth/token")
+        ).to have_been_made
+      end
+
+      it "generates a new bearer_token" do
+        expect(bearer_token).to eq "test-bearer-token"
+      end
+    end
+
+    context "when test_mode is set" do
+      before { allow(HmrcInterface.configuration).to receive(:test_mode?).and_return(true) }
+
+      it "returns a set, fake, bearer_token" do
+        expect(bearer_token).to eq "fake-hmrc-interface-bearer-token"
+      end
+    end
+  end
+end

--- a/spec/lib/hmrc_interface/configuration_spec.rb
+++ b/spec/lib/hmrc_interface/configuration_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe HmrcInterface::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe '#host' do
+    subject(:host) { described_class.new.host }
+
+    it 'defaults to nil' do
+      expect(host).to be_nil
+    end
+  end
+
+  describe '#host=' do
+    let(:config) { described_class.new }
+    let(:host) { 'https://mycustom-laa-hmrc-interface-env' }
+
+    before { config.host = host }
+
+    it 'assigns a non-default host' do
+      expect(config.host).to eql host
+    end
+  end
+
+  describe '#headers' do
+    subject(:headers) { described_class.new.headers }
+
+    it 'defaults to adding a custom User-Agent' do
+      expect(headers).to include('User-Agent' => "laa-hmrc-interface-client/#{described_class::VERSION}")
+    end
+  end
+
+  describe '#headers=' do
+    let(:config) { described_class.new }
+
+    before { config.headers = headers }
+
+    context "with non-user-agent headers added" do
+      let(:headers) { { 'Accept' => 'application/json' } }
+
+      it 'appends the header' do
+        expect(config.headers).to include(headers)
+        expect(config.headers).to include('User-Agent' => "laa-hmrc-interface-client/#{described_class::VERSION}")
+      end
+    end
+
+    context "with user-agent headers added" do
+      let(:headers) { { 'User-Agent' => 'my-own-user-agent', 'Accept' => 'application/xml' } }
+
+      it 'overwrites the existing headers' do
+        expect(config.headers).to include('Accept' => 'application/xml')
+        expect(config.headers).to include('User-Agent' => 'my-own-user-agent')
+      end
+    end
+  end
+
+  describe "#test_mode?" do
+    subject(:call) { config.test_mode? }
+
+    let(:config) { described_class.new }
+
+    context "when test_mode not set in config" do
+      it { is_expected.to be false }
+    end
+
+    context "when test_mode set to \"rubbishg\" in config" do
+      before { config.test_mode = 'not-true-string' }
+
+      it { is_expected.to be false }
+    end
+
+    context "when test_mode set to string \"true\" in config" do
+      before { config.test_mode = "true" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when test_mode set to boolean true in config" do
+      before { config.test_mode = true }
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/lib/hmrc_interface_spec.rb
+++ b/spec/lib/hmrc_interface_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe HmrcInterface do
+  it { is_expected.to respond_to :client, :configuration, :configure, :reset }
+
+  describe ".client" do
+    subject(:client) { described_class.client }
+
+    it { is_expected.to be_instance_of(described_class::Client) }
+  end
+
+  describe ".configuration" do
+    subject(:configuration) { described_class.configuration }
+
+    it { is_expected.to be_instance_of(described_class::Configuration) }
+
+    it 'memoizes the configuration' do
+      expect(configuration).to be_equal(described_class.configuration)
+    end
+
+    it "aliased to config" do
+      expect(described_class.method(:config)).to eql(described_class.method(:configuration))
+    end
+  end
+
+  describe '.configure' do
+    it 'yields a config' do
+      expect { |block| described_class.configure(&block) }.to yield_with_args(kind_of(described_class::Configuration))
+    end
+
+    it 'returns a configuration' do
+      expect(described_class.configure).to be_an_instance_of(described_class::Configuration)
+    end
+
+    context 'with configured host' do
+      let(:host) { 'https://mycustom-laa-hmrc-interface-env' }
+
+      before do
+        described_class.configure do |config|
+          config.host = host
+        end
+      end
+
+      it 'changes the host configuration' do
+        expect(described_class.configuration.host).to eql host
+      end
+    end
+  end
+
+  describe '.reset' do
+    subject(:reset) { described_class.reset }
+
+    let(:options) do
+      {
+        "headers"=>{ "User-Agent"=>"laa-hmrc-interface-client/0.0.1" },
+        "client_id"=>"my-client-id",
+        "client_secret"=>"my-client-secret",
+        "host"=>"https://mycustom-laa-hmrc-interface-env"
+      }
+    end
+
+    let(:reset_options) do
+      { "headers"=> { "User-Agent"=>"laa-hmrc-interface-client/0.0.1" } }
+    end
+
+    before do
+      described_class.configure do |config|
+        config.client_id = options["client_id"]
+        config.client_secret = options["client_secret"]
+        config.host = options["host"]
+      end
+    end
+
+    it 'resets the configured options' do
+      expect { reset }
+        .to change { described_class.configuration.as_json.to_h }
+        .from(options)
+        .to(reset_options)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,9 @@
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require "simplecov"
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
## What
Add HMRC interface client

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4056)

To encapsulate authentication calls to the HMRC interface. Also adds a custom initializer specifically 
for isolating the configuration for it.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
