### PR TITLE
Add status request specs to reach 100% coverage

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -3,7 +3,7 @@
 #
 unless ENV["NOCOVERAGE"]
   SimpleCov.start "rails" do
-    minimum_coverage 95
+    minimum_coverage 100
     enable_coverage :branch
     refuse_coverage_drop :line, :branch
 


### PR DESCRIPTION
## What
Add status controller specs to increase coverage to 100% and lockdown

- Increase status controller coverage
- Increase minimum coverage to 100%

So we do not let things slip, but minimum coverage can be reduced if deemed
necessary.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
