### PR TITLE
AP-3994: add hmrc interface result requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ Layout/LineLength:
     - config/**/*.rb
     - db/**/*.rb
     - spec/lib/hmrc_interface/request/submission_spec.rb
+    - spec/lib/hmrc_interface/request/result_spec.rb
     - spec/support/shared_contexts/hmrc_interface_stubs.rb
 
 Style/NumericLiterals:

--- a/.simplecov
+++ b/.simplecov
@@ -3,6 +3,8 @@
 #
 unless ENV["NOCOVERAGE"]
   SimpleCov.start "rails" do
+    add_filter 'lib/tasks'
+
     minimum_coverage 100
     enable_coverage :branch
     refuse_coverage_drop :line, :branch

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -6,7 +6,7 @@ We use rspec for unit and system testing.
 rspec -fd
 ```
 
-# System testing
+## System testing
 
 System tests are configured to run using `:rack_test` driver by default. For javascript dependant system tests you can use `js: true` metadata to switch to a custom registered `:headless_chrome` driver.
 
@@ -33,7 +33,7 @@ BROWSER=true bundle exec rspec
 
 see `spec/system/support/*_helper.rb` for more details
 
-# Omniauth stubbing
+## Omniauth stubbing
 
 System tests use Omniauth config to stub a single user auth hash. As long as tests create a user that matches the `auth_subject_id` or `email` address and `auth_provider` for that user then you can sign in.
 
@@ -48,6 +48,6 @@ end
 
 see `spec/system/support/omniauth_helper.rb` for more details
 
-# UAT
+## UAT
 
 In UAT we do not make calls to azure to authenticate users. Instead we allow users to authenticate with a username (email) and password. The password can be obtained from the mock_azure_password secret.

--- a/lib/hmrc_interface.rb
+++ b/lib/hmrc_interface.rb
@@ -3,6 +3,7 @@ require 'hmrc_interface/connection'
 require 'hmrc_interface/client'
 require 'hmrc_interface/error'
 require 'hmrc_interface/request/submission'
+require 'hmrc_interface/request/result'
 
 module HmrcInterface
   class << self

--- a/lib/hmrc_interface/connection.rb
+++ b/lib/hmrc_interface/connection.rb
@@ -8,7 +8,7 @@ module HmrcInterface
     def_delegator HmrcInterface, :configuration
 
     attr_reader :connection
-    def_delegators :connection, :post
+    def_delegators :connection, :post, :get
 
     def initialize(client)
       @connection = Faraday.new(url: configuration.host, headers: client.headers)

--- a/lib/hmrc_interface/error.rb
+++ b/lib/hmrc_interface/error.rb
@@ -11,6 +11,15 @@ module HmrcInterface
   end
 
   class RequestUnacceptable < StandardError
+    def initialize(message)
+      super("Unacceptable request - #{message}")
+    end
+  end
+
+  class IncompleteSubmission < StandardError
+    def initialize(message)
+      super("Incomplete submission process - #{message}")
+    end
   end
 
   class ConfigurationError < StandardError

--- a/lib/hmrc_interface/error_helper.rb
+++ b/lib/hmrc_interface/error_helper.rb
@@ -6,13 +6,13 @@ module HmrcInterface
       log_and_raise_request_error(
         message: formatted_error_message(error),
         backtrace: error.backtrace&.join("\n"),
-        http_method:,
-        http_status: error.respond_to?(:http_status) ? error.http_status : nil,
+        http_method:, # TODO: do we even need this
+        http_status: error.respond_to?(:http_status) ? error.http_status : nil, # TODO: do we even need this
       )
     end
 
     def log_and_raise_request_error(message:, backtrace: nil, http_method: "POST", http_status: nil)
-      config.logger.info { { message:, backtrace:, method: http_method, http_status: } }
+      config.logger.info { { message:, backtrace:, http_method:, http_status: } }
       raise HmrcInterface::RequestError.new(message, http_status)
     end
 
@@ -21,7 +21,7 @@ module HmrcInterface
     end
 
     def detailed_error(url, status, details)
-      "Unacceptable request: URL: #{url}, status: #{status}, details: #{details}"
+      "URL: #{url}, status: #{status}, details: #{details}"
     end
   end
 end

--- a/lib/hmrc_interface/request/base.rb
+++ b/lib/hmrc_interface/request/base.rb
@@ -5,19 +5,11 @@ module HmrcInterface
     class Base
       include HmrcInterface::ErrorHelper
 
-      Filter = Struct.new('Filter', :start_date, :end_date, :first_name, :last_name, :dob, :nino)
-
-      attr_reader :client, :use_case, :filter
+      attr_reader :client
       delegate :host, :connection, :headers, to: :client
 
-      def self.call(client, use_case, filter = {})
-        new(client, use_case, filter).call
-      end
-
-      def initialize(client, use_case, filter = {})
+      def initialize(client)
         @client = client
-        @use_case = use_case
-        @filter = Filter.new(**filter)
       end
 
     private

--- a/lib/hmrc_interface/request/result.rb
+++ b/lib/hmrc_interface/request/result.rb
@@ -1,0 +1,44 @@
+require 'hmrc_interface/request/base'
+
+module HmrcInterface
+  module Request
+    class Result < Base
+      attr_reader :submission_id
+
+      def self.call(client, submission_id)
+        new(client, submission_id).call
+      end
+
+      def initialize(client, submission_id)
+        @submission_id = submission_id
+        super(client)
+      end
+
+      def call
+        response = request
+        parsed_response = parse_json_response(response.body)
+
+        case response.status
+        when 200, 202
+          parsed_response
+        else
+          raise RequestUnacceptable, detailed_error(response.env.url,
+                                                    response.status,
+                                                    parsed_response)
+        end
+      end
+
+    private
+
+      def request
+        conn.get(url_path)
+      rescue StandardError => e
+        handle_request_error(e)
+      end
+
+      def url_path
+        @url_path ||= "api/v1/submission/result/#{submission_id}"
+      end
+    end
+  end
+end

--- a/lib/hmrc_interface/request/result.rb
+++ b/lib/hmrc_interface/request/result.rb
@@ -21,6 +21,10 @@ module HmrcInterface
         case response.status
         when 200, 202
           parsed_response
+        when 500
+          raise IncompleteSubmission, detailed_error(response.env.url,
+                                                     response.status,
+                                                     parsed_response)
         else
           raise RequestUnacceptable, detailed_error(response.env.url,
                                                     response.status,
@@ -31,9 +35,12 @@ module HmrcInterface
     private
 
       def request
-        conn.get(url_path)
+        connection.get do |request|
+          request.url url_path
+          request.headers = headers
+        end
       rescue StandardError => e
-        handle_request_error(e)
+        handle_request_error(e, "GET")
       end
 
       def url_path

--- a/lib/hmrc_interface/request/submission.rb
+++ b/lib/hmrc_interface/request/submission.rb
@@ -3,6 +3,20 @@ require 'hmrc_interface/request/base'
 module HmrcInterface
   module Request
     class Submission < Base
+      Filter = Struct.new('Filter', :start_date, :end_date, :first_name, :last_name, :dob, :nino)
+
+      attr_reader :use_case, :filter
+
+      def self.call(client, use_case, filter = {})
+        new(client, use_case, filter).call
+      end
+
+      def initialize(client, use_case, filter = {})
+        @use_case = use_case
+        @filter = Filter.new(**filter)
+        super(client)
+      end
+
       def call
         response = request
         parsed_response = parse_json_response(response.body)
@@ -11,8 +25,8 @@ module HmrcInterface
           parsed_response
         else
           raise RequestUnacceptable, detailed_error(response.env.url,
-                                                     response.status,
-                                                     parsed_response)
+                                                    response.status,
+                                                    parsed_response)
         end
       end
 

--- a/lib/hmrc_interface/request/submission.rb
+++ b/lib/hmrc_interface/request/submission.rb
@@ -57,7 +57,7 @@ module HmrcInterface
           request.body = request_body
         end
       rescue StandardError => e
-        handle_request_error(e)
+        handle_request_error(e, "POST")
       end
 
       def url_path

--- a/lib/tasks/hmrc_interface_test.rake
+++ b/lib/tasks/hmrc_interface_test.rake
@@ -1,0 +1,18 @@
+require_relative 'smoke_test'
+
+namespace :hmrc_interface do
+  desc "Run HMRC Interface test"
+  task smoke_test: :environment do
+    filter = {
+      start_date: "2020-10-01",
+      end_date: "2020-12-31",
+      first_name: "Langley",
+      last_name: "Yorke",
+      dob: "1992-07-22",
+      nino: "MN212451D",
+    }
+
+    smoke_test = HmrcInterface::SmokeTest.new(HmrcInterface.client, filter)
+    smoke_test.call
+  end
+end

--- a/lib/tasks/smoke_test.rb
+++ b/lib/tasks/smoke_test.rb
@@ -1,0 +1,38 @@
+module HmrcInterface
+  class SmokeTest
+    attr_reader :client, :filter
+
+    def initialize(client, filter = {}, duration = 5.minutes, interval = 5.seconds)
+      @client = client
+      @filter = filter
+      @duration = duration
+      @interval = interval
+    end
+
+    def call
+      submission_request = HmrcInterface::Request::Submission.new(client, :one, filter)
+      response = submission_request.call
+      submission_id = response[:id]
+
+      result_request = HmrcInterface::Request::Result.new(client, submission_id)
+      result = result_request.call
+
+      time_iterate(duration: @duration, interval: @interval) do |time|
+        result = result_request.call
+        status = result[:status]
+        puts "[#{time}]: #{status} #{result.dig(:data, 1)}"
+
+        break if %w[completed failed].include?(status.downcase)
+      end
+    end
+
+  private
+
+    def time_iterate(duration:, interval:)
+      while(Time.current <= duration.from_now)
+        yield(Time.current)
+        sleep(interval)
+      end
+    end
+  end
+end

--- a/spec/fixtures/files/hmrc_interface_successful_result_response_body.json
+++ b/spec/fixtures/files/hmrc_interface_successful_result_response_body.json
@@ -1,0 +1,404 @@
+{
+  "submission": "fake-hmrc-interface-submission-id",
+  "status": "completed",
+  "data": [
+    {
+      "correlation_id": "fake-hmrc-interface-submission-id",
+      "use_case": "use_case_one"
+    },
+    {
+      "individuals/matching/individual": {
+        "firstName": "fname",
+        "lastName": "lname",
+        "nino": "XY123456D",
+        "dateOfBirth": "1985-01-01"
+      }
+    },
+    {
+      "income/paye/paye": {
+        "income": [
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-12-18",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 16447.71,
+            "totalTaxToDate": 1366.6,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-12-18",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 16447.71,
+            "totalTaxToDate": 1366.6,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-12-18",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 16447.71,
+            "totalTaxToDate": 1366.6,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-12-18",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 16447.71,
+            "totalTaxToDate": 1366.6,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-12-18",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 16447.71,
+            "totalTaxToDate": 1366.6,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-11-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 14156.63,
+            "totalTaxToDate": 1122,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-11-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 14156.63,
+            "totalTaxToDate": 1122,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-11-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 14156.63,
+            "totalTaxToDate": 1122,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-11-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 14156.63,
+            "totalTaxToDate": 1122,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-11-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 14156.63,
+            "totalTaxToDate": 1122,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-10-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 11865.55,
+            "totalTaxToDate": 877.4,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-10-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 11865.55,
+            "totalTaxToDate": 877.4,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-10-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 11865.55,
+            "totalTaxToDate": 877.4,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-10-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 11865.55,
+            "totalTaxToDate": 877.4,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          },
+          {
+            "taxYear": "20-21",
+            "payFrequency": "M1",
+            "paymentDate": "2020-10-28",
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 11865.55,
+            "totalTaxToDate": 877.4,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2526
+            }
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/selfAssessment": {
+        "registrations": [
+          {
+            "registrationDate": "2019-02-20"
+          }
+        ],
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "submissions": []
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/pensions_and_state_benefits/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "pensionsAndStateBenefits": [
+              {
+                "totalIncome": 99999999999.9
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/source/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "sources": [
+              {
+                "businessAddress": {
+                  "line1": "ap",
+                  "line2": "ao",
+                  "line3": "ai",
+                  "line4": "au",
+                  "postalCode": "NE65 0UH"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/employments/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "employments": [
+              {
+                "employmentIncome": 99999999999.97
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/additional_information/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "additionalInformation": [
+              {
+                "gainsOnLifePolicies": 99999999999.88,
+                "sharesOptionsIncome": 99999999999.87
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/partnerships/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "partnerships": [
+              {
+                "partnershipProfit": 99999999999.96
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/uk_properties/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "ukProperties": [
+              {
+                "totalProfit": 99999999999.95
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/foreign/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "foreign": [
+              {
+                "foreignIncome": 99999999999.94
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/further_details/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "furtherDetails": [
+              {
+                "busStartDate": "2019-02-21",
+                "busEndDate": "2019-02-22",
+                "totalTaxPaid": -99.99,
+                "totalNIC": 99999999999.99,
+                "turnover": 345435.03,
+                "tradingIncomeAllowance": 100,
+                "deducts": {
+                  "totalBusExpenses": 99999999999.86,
+                  "totalDisallowBusExp": 99999999999.85
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/interests_and_dividends/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "interestsAndDividends": [
+              {
+                "ukInterestsIncome": 99999999999.92,
+                "foreignDividendsIncome": 99999999999.93,
+                "ukDividendsIncome": 99999999999.91
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/other/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "other": [
+              {
+                "otherIncome": 99999999999.89
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/summary/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "summary": [
+              {
+                "totalIncome": 99999999999.99
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/trusts/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "trusts": [
+              {
+                "trustIncome": 99999999999.98
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "employments/paye/employments": [
+        {
+          "startDate": "2017-07-24",
+          "endDate": "2099-12-31"
+        }
+      ]
+    },
+    {
+      "benefits_and_credits/working_tax_credit/applications": []
+    },
+    {
+      "benefits_and_credits/child_tax_credit/applications": []
+    }
+  ]
+}

--- a/spec/lib/hmrc_interface/connection_spec.rb
+++ b/spec/lib/hmrc_interface/connection_spec.rb
@@ -45,4 +45,12 @@ RSpec.describe HmrcInterface::Connection do
       expect(instance.connection).to have_received(:post)
      end
   end
+
+  describe "#get" do
+    it "is delegated to connection instance" do
+      allow(instance.connection).to receive(:get)
+      instance.get
+      expect(instance.connection).to have_received(:get)
+     end
+  end
 end

--- a/spec/lib/hmrc_interface/request/result_spec.rb
+++ b/spec/lib/hmrc_interface/request/result_spec.rb
@@ -1,0 +1,273 @@
+require "rails_helper"
+
+RSpec.describe HmrcInterface::Request::Result do
+  subject(:instance) { described_class.new(client, submission_id) }
+
+  let(:client) { HmrcInterface.client }
+  let(:submission_id) { "fake-hmrc-interface-submission-id" }
+
+  describe "#call" do
+    subject(:call) { instance.call }
+
+    context "when a successful \"completed\" response is received" do
+      include_context "with stubbed hmrc-interface result completed"
+      include_context "with nil access token"
+
+      it "submits expected token request" do
+        call
+
+        expect(
+          a_request(
+            :post,
+            "#{fake_host}/oauth/token"
+          ).with(body: "grant_type=client_credentials",
+                 headers: { 'Accept'=>'*/*',
+                            'Content-Type'=>'application/x-www-form-urlencoded',
+                            'Accept-Encoding'=>/.*/,
+                            'Authorization'=>/Basic .*/ })
+        ).to have_been_made.at_least_once
+      end
+
+      it "submits expected submission result request" do
+        call
+
+        expect(
+          a_request(
+            :get,
+            "#{fake_host}/api/v1/submission/result/#{submission_id}"
+          ).with(headers: { 'Accept'=>'application/json',
+                            'Content-Type'=>'application/json',
+                            'Accept-Encoding'=>/.*/,
+                            'Authorization'=>'Bearer test-bearer-token',
+                            'User-Agent'=>'laa-hmrc-interface-client/0.0.1'})
+        ).to have_been_made.once
+      end
+
+      it "returns expected parsed JSON response" do
+        file = file_fixture("hmrc_interface_successful_result_response_body.json")
+        json = file.read
+        parsed_json = JSON.parse(json, symbolize_names: true)
+
+        expect(call).to match(parsed_json)
+      end
+    end
+
+    context "when a \"processing\" response is received" do
+      include_context "with stubbed host and bearer token"
+
+      before do
+        stub_request(:get, %r{#{fake_host}/api/v1/submission/result/.*})
+          .to_return(
+            status: 202,
+            body: expected_body.to_json,
+            headers: { "Content-Type" => "application/json; charset=utf-8" },
+          )
+      end
+
+      let(:expected_body) do
+        {
+          submission: "fake-hmrc-interface-submission-id",
+          status: "processing",
+          _links: [href: "#{fake_host}/api/v1/submission/status/#{submission_id}"]
+        }
+      end
+
+      it "returns expected parsed JSON response" do
+        expect(call).to match(expected_body)
+      end
+    end
+
+    context "when a \"failed\" response is received (client details not found)" do
+      include_context "with stubbed host and bearer token"
+
+      before do
+        stub_request(:get, %r{#{fake_host}/api/v1/submission/result/.*})
+          .to_return(
+            status: 200,
+            body: expected_body.to_json,
+            headers: { "Content-Type" => "application/json; charset=utf-8" },
+          )
+      end
+
+      let(:expected_body) do
+        {
+          submission: "fake-hmrc-interface-submission-id",
+          status: "processing",
+          data: [
+            { correlation_id: submission_id, use_case: "use_case_one" },
+            { error: "submitted client details could not be found in HMRC service" },
+          ]
+        }
+      end
+
+      it "returns expected parsed JSON response" do
+        expect(call).to match(expected_body)
+      end
+    end
+
+    # taken from hmrc interface `submissions_controller#result` action
+    context "when an :internal_server_error is received" do
+      include_context "with stubbed host and bearer token"
+
+      before do
+        stub_request(:get, %r{#{fake_host}/api/v1/submission/result/.*})
+          .to_return(
+            status: 500,
+            body: expected_body.to_json,
+            headers: { "Content-Type" => "application/json; charset=utf-8" },
+          )
+      end
+
+      let(:expected_body) do
+        {
+          submission: "fake-hmrc-interface-submission-id",
+          status: "processing",
+          code: "INCOMPLETE_SUBMISSION",
+          message: "Process complete but no result available"
+        }
+      end
+
+      it "raises HmrcInterface::RequestUnacceptable error with expected message" do
+          expect { call }
+            .to raise_error(HmrcInterface::IncompleteSubmission,
+                            "Incomplete submission process - URL: #{fake_host}/api/v1/submission/result/fake-hmrc-interface-submission-id, status: 500, details: #{expected_body}")
+        end
+    end
+
+    context "when an error occurs in authentication" do
+      include_context "with stubbed host"
+      include_context "with nil access token"
+
+      context "with invalid credentials" do
+        before do
+          stub_request(:post, %r{#{fake_host}/oauth/token})
+            .to_raise(OAuth2::Error)
+        end
+
+        it "logs the exception as information and raises HmrcInterface::RequestError error" do
+          allow(Rails.logger).to receive(:info).and_call_original
+
+          expect { call }.to raise_error HmrcInterface::RequestError, /#{described_class} received OAuth2::Error/
+
+          expect(Rails.logger)
+            .to have_received(:info) do |&block|
+                  expect(block.call)
+                    .to include(message:/#{described_class} received OAuth2::Error/)
+                    .and include(backtrace: /.*/)
+                    .and include(http_method: "GET")
+                    .and include(http_status: nil)
+                end
+        end
+      end
+    end
+
+    context "when an error occurs in the submission result process" do
+      context "with unexpected error StandardError" do
+        include_context "with stubbed hmrc-interface submission result StandardError"
+
+        it "logs the exception as information and raises HmrcInterface::RequestError error" do
+          allow(Rails.logger).to receive(:info).and_call_original
+
+          expect { call }.to raise_error HmrcInterface::RequestError, /#{described_class} received StandardError/
+
+          expect(Rails.logger)
+            .to have_received(:info) do |&block|
+                  expect(block.call)
+                    .to include(message:/#{described_class} received StandardError/)
+                    .and include(backtrace: /.*/)
+                    .and include(http_method: "GET")
+                    .and include(http_status: nil)
+                end
+        end
+      end
+
+      context "with bad request response" do
+        include_context "with stubbed host and bearer token"
+
+        let(:fake_error_body) do
+          {
+            success: false,
+            error_class: "FakeHmrcInterface::BadRequest",
+            message: "fake error message",
+            backtrace: ["fake error backtrace"],
+          }
+        end
+
+        before do
+           stub_request(:get, %r{#{fake_host}/api/v1/submission/result/.*})
+            .to_return(
+              status: 400,
+              body: fake_error_body.to_json
+            )
+        end
+
+        it "raises HmrcInterface::RequestUnacceptable error with expected message" do
+          expect { call }
+            .to raise_error(HmrcInterface::RequestUnacceptable,
+                            "Unacceptable request - URL: #{fake_host}/api/v1/submission/result/fake-hmrc-interface-submission-id, status: 400, details: #{fake_error_body}")
+        end
+      end
+
+      context "with internal server error response" do
+        include_context "with stubbed host and bearer token"
+
+        let(:fake_error_body) do
+          {
+            success: false,
+            error_class: "FakeHmrcInterface::InternalServerError",
+            message: "fake error message",
+            backtrace: ["fake error backtrace"],
+          }
+        end
+
+        before do
+          stub_request(:get, %r{#{fake_host}/api/v1/submission/result/.*})
+            .to_return(
+              status: 503,
+              body: fake_error_body.to_json
+            )
+        end
+
+        it "raises HmrcInterface::RequestUnacceptable error with expected message" do
+          expect { call }
+            .to raise_error(HmrcInterface::RequestUnacceptable,
+                            "Unacceptable request - URL: #{fake_host}/api/v1/submission/result/fake-hmrc-interface-submission-id, status: 503, details: #{fake_error_body}")
+        end
+      end
+
+      context "with internal server error response and malformed JSON" do
+        include_context "with stubbed host and bearer token"
+
+        let(:malformed_json_error_body) { "something went wrong!!" }
+
+        before do
+          stub_request(:get, %r{#{fake_host}/api/v1/submission/result/.*})
+            .to_return(
+              status: 503,
+              body: malformed_json_error_body
+            )
+        end
+
+        it "raises HmrcInterface::RequestUnacceptable error with expected message" do
+          expect { call }
+            .to raise_error(HmrcInterface::RequestUnacceptable,
+                            "Unacceptable request - URL: #{fake_host}/api/v1/submission/result/fake-hmrc-interface-submission-id, status: 503, details: #{malformed_json_error_body}")
+        end
+      end
+    end
+  end
+
+  describe ".call" do
+    subject(:call) { described_class.call(client, submission_id) }
+
+    include_context "with stubbed hmrc-interface result completed"
+
+    it "returns expected parsed JSON response" do
+      file = file_fixture("hmrc_interface_successful_result_response_body.json")
+      json = file.read
+      parsed_json = JSON.parse(json, symbolize_names: true)
+
+      expect(call).to match(parsed_json)
+    end
+  end
+end

--- a/spec/lib/hmrc_interface/request/submission_spec.rb
+++ b/spec/lib/hmrc_interface/request/submission_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe HmrcInterface::Request::Submission do
                   expect(block.call)
                     .to include(message:/#{described_class} received OAuth2::Error/)
                     .and include(backtrace: /.*/)
-                    .and include(method: "POST")
+                    .and include(http_method: "POST")
                     .and include(http_status: nil)
                 end
         end
@@ -106,7 +106,7 @@ RSpec.describe HmrcInterface::Request::Submission do
                   expect(block.call)
                     .to include(message:/#{described_class} received StandardError/)
                     .and include(backtrace: /.*/)
-                    .and include(method: "POST")
+                    .and include(http_method: "POST")
                     .and include(http_status: nil)
                 end
         end
@@ -135,7 +135,7 @@ RSpec.describe HmrcInterface::Request::Submission do
         it "raises HmrcInterface::RequestUnacceptable error with expected message" do
           expect { call }
             .to raise_error(HmrcInterface::RequestUnacceptable,
-                            "Unacceptable request: URL: #{fake_host}/api/v1/submission/create/one, status: 400, details: #{fake_error_body}")
+                            "Unacceptable request - URL: #{fake_host}/api/v1/submission/create/one, status: 400, details: #{fake_error_body}")
         end
       end
 
@@ -162,7 +162,7 @@ RSpec.describe HmrcInterface::Request::Submission do
         it "raises HmrcInterface::RequestUnacceptable error with expected message" do
           expect { call }
             .to raise_error(HmrcInterface::RequestUnacceptable,
-                            "Unacceptable request: URL: #{fake_host}/api/v1/submission/create/one, status: 503, details: #{fake_error_body}")
+                            "Unacceptable request - URL: #{fake_host}/api/v1/submission/create/one, status: 503, details: #{fake_error_body}")
         end
       end
 
@@ -182,7 +182,7 @@ RSpec.describe HmrcInterface::Request::Submission do
         it "raises HmrcInterface::RequestUnacceptable error with expected message" do
           expect { call }
             .to raise_error(HmrcInterface::RequestUnacceptable,
-                            "Unacceptable request: URL: #{fake_host}/api/v1/submission/create/one, status: 503, details: #{malformed_json_error_body}")
+                            "Unacceptable request - URL: #{fake_host}/api/v1/submission/create/one, status: 503, details: #{malformed_json_error_body}")
         end
       end
     end

--- a/spec/support/shared_contexts/hmrc_interface_stubs.rb
+++ b/spec/support/shared_contexts/hmrc_interface_stubs.rb
@@ -40,11 +40,46 @@ RSpec.shared_context "with stubbed hmrc-interface submission success" do
   end
 end
 
+RSpec.shared_context "with stubbed hmrc-interface result completed" do
+  include_context "with stubbed host and bearer token"
+
+  before do
+    stub_request(:get, %r{#{fake_host}/api/v1/submission/result/.*})
+      .to_return(
+        status: 200,
+        body: file_fixture("hmrc_interface_successful_result_response_body.json").read,
+        headers: { "Content-Type" => "application/json; charset=utf-8" },
+      )
+  end
+end
+
+RSpec.shared_context "with stubbed hmrc-interface result in_progress" do
+  include_context "with stubbed host and bearer token"
+
+  before do
+    stub_request(:get, %r{#{fake_host}/api/v1/submission/result/.*})
+      .to_return(
+        status: 200,
+        body: file_fixture("hmrc_interface_successful_result_response_body.json").read,
+        headers: { "Content-Type" => "application/json; charset=utf-8" },
+      )
+  end
+end
+
 RSpec.shared_context "with stubbed hmrc-interface submission StandardError" do
   include_context "with stubbed host and bearer token"
 
   before do
     stub_request(:post, %r{#{fake_host}/api/v1/submission/create/.*})
+      .to_raise(StandardError)
+  end
+end
+
+RSpec.shared_context "with stubbed hmrc-interface submission result StandardError" do
+  include_context "with stubbed host and bearer token"
+
+  before do
+    stub_request(:get, %r{#{fake_host}/api/v1/submission/result/.*})
       .to_raise(StandardError)
   end
 end


### PR DESCRIPTION
## What
Enable request of result endpoint for a previous submission

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3994)

This `HmrcInterface::Request::Result`class will allow polling of the result from HMRC interface
for a given, previously queried, submission.


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
