### PR TITLE
Remove old hosted zone domain

### DIFF
--- a/.helm/assure-hmrc-data/values/production.yaml
+++ b/.helm/assure-hmrc-data/values/production.yaml
@@ -28,12 +28,9 @@ ingress:
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6,setvar:tx.outbound_anomaly_score_threshold=4"
       SecRuleUpdateActionById 949110 "t:none,deny,status:423,logdata:%{SERVER_NAME}"
   hosts:
-    - assure-hmrc-data.service.justice.gov.uk
     - check-clients-details-using-hmrc-data.service.justice.gov.uk
   tls:
     - hosts:
-      - domain: assure-hmrc-data.service.justice.gov.uk
-        secretName: assure-hmrc-data-tls-certificate
       - domain: check-clients-details-using-hmrc-data.service.justice.gov.uk
         secretName: check-clients-details-using-hmrc-data-tls-certificate
 

--- a/.helm/assure-hmrc-data/values/staging.yaml
+++ b/.helm/assure-hmrc-data/values/staging.yaml
@@ -30,12 +30,9 @@ ingress:
   hosts:
     - laa-assure-hmrc-data-staging.cloud-platform.service.justice.gov.uk
     - laa-assure-hmrc-data-staging.apps.live.cloud-platform.service.justice.gov.uk
-    - staging.assure-hmrc-data.service.justice.gov.uk
     - staging.check-clients-details-using-hmrc-data.service.justice.gov.uk
   tls:
     - hosts:
-      - domain: staging.assure-hmrc-data.service.justice.gov.uk
-        secretName: assure-hmrc-data-tls-certificate
       - domain: staging.check-clients-details-using-hmrc-data.service.justice.gov.uk
         secretName: check-clients-details-using-hmrc-data-tls-certificate
 


### PR DESCRIPTION
## What
Remove old hosted zone ingress

To remove complexity and failed login paths due to redirect URL issues going from old custom domain to new.

It is not possible to sign in via the old staging and production
hosted zone `assure-hmrc-data.service.justice.gov.uk` without being
redirected back, by AzureAD, to the new hosted zone
`check-clients-details-using-hmrc-data.service.justice.gov.uk`. This
then causes an authentication failure.

- [X] remove ingress
- [x] remove azure AD app registration redirect url
- [x] remove hosted zone, on cloud platform.  
- [x] remove secret on cloud platform

see [this PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/12940) and [this one](https://github.com/ministryofjustice/cloud-platform-environments/pull/12939) for Cloud platform changes


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
