### PR TITLE
Only allow mock user to login using mock password

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,13 +6,19 @@
 OMNIAUTH_AZURE_CLIENT_ID='TestAzureClientID'
 OMNIAUTH_AZURE_TENANT_ID='TestAzureTenantID'
 
-# default redirect_uri is taken from azure unless overwritten
+# default redirect_uri is taken from azure unless supplied here
 OMNIAUTH_AZURE_REDIRECT_URI=
 
 # create "laa-assure-hmrc-data [your-name]" in Azure AD
 OMNIAUTH_AZURE_CLIENT_SECRET='TestAzureClientSecret'
 
-MOCK_AZURE=false
+# ---------------------------------------------------------------
+# Mock login credentials
+# localhost (and UAT) defined env vars for bypassing azure AD
+# ---------------------------------------------------------------
+
+MOCK_AZURE=true
+MOCK_AZURE_USERNAME='john.doe@example.com'
 MOCK_AZURE_PASSWORD='password'
 
 # --------------------------

--- a/.helm/assure-hmrc-data/templates/_envs.tpl
+++ b/.helm/assure-hmrc-data/templates/_envs.tpl
@@ -115,6 +115,11 @@ env:
   - name: MOCK_AZURE
     value: {{ .Values.mock_azure.enabled | quote }}
   {{ if .Values.mock_azure.enabled }}
+  - name: MOCK_AZURE_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: assure-hmrc-data-application-output
+        key: mock_azure_username
   - name: MOCK_AZURE_PASSWORD
     valueFrom:
       secretKeyRef:

--- a/app/controllers/users/mock_azure_controller.rb
+++ b/app/controllers/users/mock_azure_controller.rb
@@ -1,10 +1,12 @@
 class Users::MockAzureController < Devise::SessionsController
   def create
-    @user = User.find_by(email: mock_azure_params[:email])
+    user = User.find_by(email: mock_azure_params[:email])
 
-    if(@user && mock_azure_params[:password] == Rails.configuration.x.mock_azure_password)
+    if(mock_azure_params[:email] == Rails.configuration.x.mock_azure_username &&
+       mock_azure_params[:password] == Rails.configuration.x.mock_azure_password &&
+       user)
       flash[:notice] = I18n.t "devise.sessions.signed_in"
-      sign_in_and_redirect @user, event: :authentication
+      sign_in_and_redirect user, event: :authentication
     else
       flash[:notice] = I18n.t "devise.omniauth_callbacks.unauthorised"
       redirect_back(fallback_location: unauthenticated_root_path)

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,7 @@ module LaaAssureHmrcData
     config.active_record.encryption.key_derivation_salt = ENV.fetch("AR_ENCRYPTION_KEY_DERIVATION_SALT", "fake-key-derivation-salt")
 
     config.x.mock_azure = ENV.fetch("MOCK_AZURE", "false")=="true"
+    config.x.mock_azure_username = ENV.fetch("MOCK_AZURE_USERNAME", nil)
     config.x.mock_azure_password = ENV.fetch("MOCK_AZURE_PASSWORD", nil)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,6 @@ test_users.each do |attributes|
   User.create_or_find_by!(attributes)
 end
 
-User.create_or_find_by!(email: 'mock.azure@justice.gov.uk',
-                        first_name: 'mock',
-                        last_name: 'azure') if Rails.configuration.x.mock_azure
+User.create_or_find_by!(email: Rails.configuration.x.mock_azure_username,
+                        first_name: 'Mock',
+                        last_name: 'Azure') if Rails.configuration.x.mock_azure

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -82,4 +82,6 @@ $ rails console
 ### Mock azure login
 
 If the MOCK_AZURE env var is set to "true" it will be possible to bypass azure authentication and login
-as any user that exists in the database, using user's email and password as the value contained in the MOCK_AZURE_PASSWORD env var.
+as the mock azure user that is seeded in the database. The mock user's login details are supplied via
+`MOCK_AZURE_USERNAME` and `MOCK_AZURE_PASSWORD` env var values included in the seeds (i.e. by `db:seed`)
+

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -50,4 +50,4 @@ see `spec/system/support/omniauth_helper.rb` for more details
 
 ## UAT
 
-In UAT we do not make calls to azure to authenticate users. Instead we allow users to authenticate with a username (email) and password. The password can be obtained from the mock_azure_password secret.
+In UAT we do not make calls to azure to authenticate users. Instead we allow users to authenticate with a username (email) and password. The user name and password can be obtained from the mock_azure_username and mock_azure_password secret values respectively.

--- a/spec/requests/users/mock_azure_controller_spec.rb
+++ b/spec/requests/users/mock_azure_controller_spec.rb
@@ -26,19 +26,22 @@ RSpec.describe Users::MockAzureController, type: :request do
     before do
       user
       allow(Rails.configuration.x).to receive(:mock_azure).and_return(true)
+      allow(Rails.configuration.x).to receive(:mock_azure_username).and_return(username)
       allow(Rails.configuration.x).to receive(:mock_azure_password).and_return("mockazurepassword")
       Rails.application.reload_routes!
       post user_session_path, params:
     end
 
+    let(:username) { "mock.azure@example.com" }
+
     let(:user) do
-      User.create!(email: "mock.azure@example.co.uk",
+      User.create!(email: "mock.azure@example.com",
                    first_name: "Mock",
                    last_name: "Azure")
     end
 
     context "when username and password are correct" do
-      let(:params) { { user: { email: 'mock.azure@example.co.uk', password: 'mockazurepassword' } } }
+      let(:params) { { user: { email: username, password: 'mockazurepassword' } } }
 
       it "redirects to authenticated users root path" do
         expect(flash[:notice]).to match(/Signed in successfully./)
@@ -47,7 +50,20 @@ RSpec.describe Users::MockAzureController, type: :request do
     end
 
     context "when user doesn't exist" do
-      let(:params) { { user: { email: 'no.user@example.co.uk', password: 'mockazurepassword' } } }
+      let(:params) { { user: { email: 'no.user@example.com', password: 'irrelevant' } } }
+
+      it "redirects to fallback location and sets flash" do
+        expect(flash[:notice]).to match(/User not found or authorised!/)
+        expect(response).to redirect_to(unauthenticated_root_path)
+      end
+    end
+
+    context "when user exists and password is valid mock password but is not the mock user" do
+      let(:params) { { user: { email: 'jim.bob@example.com', password: 'mockazurepassword' } } }
+
+      let(:user) do
+        User.create!(email: "jim.bob@example.com")
+      end
 
       it "redirects to fallback location and sets flash" do
         expect(flash[:notice]).to match(/User not found or authorised!/)
@@ -56,7 +72,7 @@ RSpec.describe Users::MockAzureController, type: :request do
     end
 
     context "when password is incorrect" do
-      let(:params) { { user: { email: 'mock.azure@example.co.uk', password: 'awrongpassword' } } }
+      let(:params) { { user: { email: username, password: 'awrongpassword' } } }
 
       it "redirects to fallback location and sets flash" do
         expect(flash[:notice]).to match(/User not found or authorised!/)


### PR DESCRIPTION
## What
Only allow mock user to login using mock password

Allowing any user to login with the mock password
means they never get a first name and last name from azure
which results in empty text for the navigation item link.

It seems better IMO to have just one user for mock login in any
event as _current behaviour means anyone with the mock password can
login as anyone else._

I also moved the username (email) to the secrets for additional
security.

## Note

`MOCK_AZURE_USERNAME` env var has been added to UAT application secrets as part of this! I have changed the username from the one previously seeded so you will need to check the secrets to get it.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
