### PR TITLE
Add Rails.host.env methods

### DIFF
--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -1,0 +1,5 @@
+Dir[Rails.root.join('lib/extensions/*.rb')].each { |file| require file }
+
+module Rails
+  extend RailsModuleExtension
+end

--- a/lib/extensions/rails_module_extension.rb
+++ b/lib/extensions/rails_module_extension.rb
@@ -1,0 +1,7 @@
+require Rails.root.join('lib/rails_host.rb')
+
+module RailsModuleExtension
+  def host
+    RailsHost
+  end
+end

--- a/lib/rails_host.rb
+++ b/lib/rails_host.rb
@@ -1,0 +1,21 @@
+class RailsHost
+  VALID_ENVS = %w[uat staging production].freeze
+
+  def self.env
+    Rails.configuration.x.host_env
+  end
+
+  def self.method_missing(method)
+    env_name = method.to_s.tr('_', '-').sub(/\?$/, '')
+    if VALID_ENVS.include?(env_name)
+      env == env_name
+    else
+      super
+    end
+  end
+
+  def self.respond_to_missing?(method, include_private = false)
+    env_name = method.to_s.tr('_', '-').sub(/\?$/, '')
+    VALID_ENVS.include?(env_name) || super
+  end
+end

--- a/lib/rails_host_spec.rb
+++ b/lib/rails_host_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe RailsHost do
+  around do |example|
+    with_env(environment) { example.run }
+  end
+
+  describe '.env' do
+    subject { described_class.env }
+
+    context 'when host_env is uat' do
+      let(:environment) { 'uat' }
+
+      it { is_expected.to eq('uat') }
+    end
+
+    context 'when host_env is staging' do
+      let(:environment) { 'staging' }
+
+      it { is_expected.to eq('staging') }
+    end
+
+    context 'when host_env is production' do
+      let(:environment) { 'production' }
+
+      it { is_expected.to eq('production') }
+    end
+
+    context 'when host_env is gibberish' do
+      let(:environment) { 'gibberish' }
+
+      it { is_expected.to eq('gibberish') }
+    end
+  end
+
+  describe '.host' do
+    context 'when host_env is uat' do
+      let(:environment) { 'uat' }
+
+      it 'returns the rails host envirobment name' do
+        expect(Rails.host.env).to eq 'uat'
+      end
+
+      it 'returns true for #uat?' do
+        expect(Rails.host.uat?).to be true
+      end
+
+      it 'returns false for #staging?' do
+        expect(Rails.host.staging?).to be false
+      end
+
+      it 'returns false for #production?' do
+        expect(Rails.host.production?).to be false
+      end
+    end
+
+    context 'when host_env is staging' do
+      let(:environment) { 'staging' }
+
+      it 'returns the rails environement host name' do
+        expect(Rails.host.env).to eq 'staging'
+      end
+
+      it 'returns true for #staging?' do
+        expect(Rails.host.staging?).to be true
+      end
+
+      it 'returns false for #production?' do
+        expect(Rails.host.production?).to be false
+      end
+
+      it 'returns false for #uat?' do
+        expect(Rails.host.uat?).to be false
+      end
+    end
+
+    context 'when host_env is production' do
+      let(:environment) { 'production' }
+
+      it 'returns the rails environement host name' do
+        expect(Rails.host.env).to eq 'production'
+      end
+
+      it 'returns true for #production?' do
+        expect(Rails.host.production?).to be true
+      end
+
+      it 'returns false for #staging?' do
+        expect(Rails.host.staging?).to be false
+      end
+
+      it 'returns false for #uat?' do
+        expect(Rails.host.uat?).to be false
+      end
+    end
+
+    context 'when host environment is not a valid/allowed environment' do
+      let(:environment) { 'gibberish' }
+
+      it 'raises method missing if invalid method name' do
+        expect {
+          Rails.host.gibberish?
+        }.to raise_error NoMethodError, /undefined method .gibberish\?/
+      end
+    end
+  end
+end

--- a/spec/lib/rails_host_spec.rb
+++ b/spec/lib/rails_host_spec.rb
@@ -104,4 +104,12 @@ RSpec.describe RailsHost do
       end
     end
   end
+
+  describe '.respond_to_missing' do
+    let(:environment) { 'staging' }
+
+    it 'raises error when missing method called using `method`' do
+        expect { Rails.host.method(:my_missing_method) }.to raise_error NameError, /undefined method `my_missing_method/
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,4 +66,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+
+  # application test suite specific helpers
+  config.include TestHelpers
 end

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -1,0 +1,17 @@
+# Methods here are exposed globally to all rspec tests, but do not abuse this.
+# Do not require external dependencies in this file, and only use it when the
+# methods are going to be used in a lot of specs.
+#
+# Requiring heavyweight dependencies from this file will add to the boot time of
+# the test suite on EVERY test run.
+# Instead, consider making a separate helper file and requiring it from the spec
+# file or files that actually need it.
+module TestHelpers
+  def with_env(env)
+    @original_env = Rails.configuration.x.host_env
+    Rails.configuration.x.host_env = env
+    yield
+  ensure
+    Rails.configuration.x.host_env = @original_env
+  end
+end


### PR DESCRIPTION
## What
Add Rails host environment extension

Add shorthand methods to use for differentiating
what host environment we are on. This allows
us to add clear and concise conditionals
for functionality that should only be available
on a given host.

e.g. 
```ruby
if Rails.host.uat?
...
end

Rails.logger.info "[#{Rails.host.env}] doing something..."
```


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
