### PR TITLE
AP-4043: gitignore dump.rdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ coverage/
 
 *.code-workspace
 *.sha256
+
+# Ignore Redis binary dump (dump.rdb) files
+*.rdb


### PR DESCRIPTION



## What
Add dump.rdb to .gitignore

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4043)

ignore local redis dump files as we do not want local generated data in the codebase

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
