### PR TITLE
ap-4166: use short-lived ecr credentials in test-build-deploy workflow

### DIFF
--- a/.github/actions/build_and_push/action.yml
+++ b/.github/actions/build_and_push/action.yml
@@ -4,14 +4,11 @@ inputs:
   ecr-region:
     description: "ECR region"
     required: true
-  ecr-url:
-    description: "ECR endpoint url"
+  ecr-role-to-assume:
+    description: "ECR role to assume"
     required: true
-  ecr-access-key-id:
-    description: "AWS access key id for ECR"
-    required: true
-  ecr-secret-access-key:
-    description: "AWS secret access key for ECR"
+  ecr-repository:
+    description: "ECR repository"
     required: true
 
 runs:
@@ -21,15 +18,15 @@ runs:
       shell: bash
       run: echo "BUILD_DATE=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
 
+    - name: Assume role in Cloud Platform
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ inputs.ecr-role-to-assume }}
+        aws-region: ${{ inputs.ecr-region }}
+
     - name: Docker login to ECR
-      shell: bash
-      env:
-        ECR_REGION: ${{ inputs.ecr-region }}
-        ECR_URL: ${{ inputs.ecr-url }}
-        AWS_ACCESS_KEY_ID: ${{ inputs.ecr-access-key-id }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.ecr-secret-access-key }}
-      run: |
-        aws ecr get-login-password --region ${ECR_REGION} | docker login --username AWS --password-stdin ${ECR_URL}
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
 
     - name: Extract release name
       id: extract_release_name
@@ -52,13 +49,14 @@ runs:
     - name: Push to ECR
       shell: bash
       env:
-        ECR_URL: ${{ inputs.ecr-url }}
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: ${{ inputs.ecr-repository }}
         GIT_SHA: ${{ github.sha }}
       run: |
-        docker tag app "${ECR_URL}:${GIT_SHA}"
-        docker push "${ECR_URL}:${GIT_SHA}"
+        docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:${GIT_SHA}"
+        docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${GIT_SHA}"
 
         if [ ${{ github.ref }} == 'refs/heads/main' ]; then
-          docker tag app "${ECR_URL}:latest"
-          docker push "${ECR_URL}:latest"
+          docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
         fi

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,8 +1,14 @@
 name: "Deploy"
 description: 'Deploy docker image to namespace'
 inputs:
-  ecr-url:
-    description: "ECR endpoint url"
+  ecr-repository:
+    description: "ECR repository"
+    required: true
+  ecr-region:
+    description: "ECR region"
+    required: true
+  ecr-role-to-assume:
+    description: "ECR role to assume"
     required: true
   kube-cert:
     description: "Kubernetes cluster authentication certificate"
@@ -34,10 +40,21 @@ runs:
         kube-cluster: ${{ inputs.kube-cluster }}
         kube-namespace: ${{ inputs.kube-namespace }}
 
+    - name: Assume role in Cloud Platform
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ inputs.ecr-role-to-assume }}
+        aws-region: ${{ inputs.ecr-region }}
+
+    - name: Docker login to ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
     - name: Helm deployment
       shell: bash
       env:
-        ECR_URL: ${{ inputs.ecr-url }}
+        ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         GIT_SHA: ${{ github.sha }}
         KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
         VALUES_FILE: .helm/assure-hmrc-data/values/${{ inputs.app-environment }}.yaml
@@ -46,7 +63,7 @@ runs:
 
         helm upgrade assure-hmrc-data .helm/assure-hmrc-data \
           --namespace ${KUBE_NAMESPACE} \
-          --set image.repository="${ECR_URL}" \
+          --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
           --set image.tag="${GIT_SHA}" \
           --set ingress.annotations."nginx\.ingress\.kubernetes\.io/whitelist-source-range"=$allow_list \
           --values ${VALUES_FILE} \

--- a/.github/actions/deploy_branch/action.yml
+++ b/.github/actions/deploy_branch/action.yml
@@ -1,8 +1,14 @@
 name: "Deploy branch"
 description: 'Deploy docker image of branch to namespace with an ingress based on branch name'
 inputs:
-  ecr-url:
-    description: "ECR endpoint url"
+  ecr-repository:
+    description: "ECR repository"
+    required: true
+  ecr-region:
+    description: "ECR region"
+    required: true
+  ecr-role-to-assume:
+    description: "ECR role to assume"
     required: true
   kube-cert:
     description: "Kubernetes cluster authentication certificate"
@@ -46,10 +52,21 @@ runs:
         kube-cluster: ${{ inputs.kube-cluster }}
         kube-namespace: ${{ inputs.kube-namespace }}
 
+    - name: Assume role in Cloud Platform
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ inputs.ecr-role-to-assume }}
+        aws-region: ${{ inputs.ecr-region }}
+
+    - name: Docker login to ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
     - name: Helm deployment of branch
       shell: bash
       env:
-        ECR_URL: ${{ inputs.ecr-url }}
+        ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         GIT_SHA: ${{ github.sha }}
         KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
         VALUES_FILE: .helm/assure-hmrc-data/values/${{ inputs.app-environment }}.yaml
@@ -63,7 +80,7 @@ runs:
 
         helm upgrade $RELEASE_NAME .helm/assure-hmrc-data \
           --namespace ${KUBE_NAMESPACE} \
-          --set image.repository="${ECR_URL}" \
+          --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
           --set image.tag="${GIT_SHA}" \
           --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$identifier" \
           --set ingress.hosts="{$release_host}" \

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -82,6 +82,9 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -91,15 +94,17 @@ jobs:
         id: build_and_push
         uses: ./.github/actions/build_and_push
         with:
-          ecr-region: ${{ secrets.ECR_AWS_DEFAULT_REGION }}
-          ecr-url: ${{ secrets.ECR_TEAM_REPO_URL }}
-          ecr-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          ecr-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          ecr-region: ${{ vars.ECR_REGION }}
+          ecr-role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          ecr-repository: ${{ vars.ECR_REPOSITORY }}
 
   deploy-uat:
     runs-on: ubuntu-latest
     needs: build
     environment: uat
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -109,7 +114,9 @@ jobs:
         id: deploy_uat_branch
         uses: ./.github/actions/deploy_branch
         with:
-          ecr-url: ${{ secrets.ECR_TEAM_REPO_URL }}
+          ecr-region: ${{ vars.ECR_REGION }}
+          ecr-role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          ecr-repository: ${{ vars.ECR_REPOSITORY }}
           kube-cert: ${{ secrets.KUBE_UAT_CERT }}
           kube-token: ${{ secrets.KUBE_UAT_TOKEN }}
           kube-cluster: ${{ secrets.KUBE_UAT_CLUSTER }}
@@ -121,6 +128,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment: staging
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -130,7 +140,9 @@ jobs:
         id: deploy_staging
         uses: ./.github/actions/deploy
         with:
-          ecr-url: ${{ secrets.ECR_TEAM_REPO_URL }}
+          ecr-region: ${{ vars.ECR_REGION }}
+          ecr-role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          ecr-repository: ${{ vars.ECR_REPOSITORY }}
           kube-cert: ${{ secrets.KUBE_STAGING_CERT }}
           kube-token: ${{ secrets.KUBE_STAGING_TOKEN }}
           kube-cluster: ${{ secrets.KUBE_STAGING_CLUSTER }}
@@ -142,6 +154,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy-staging
     environment: production
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -151,7 +166,9 @@ jobs:
         id: deploy_staging
         uses: ./.github/actions/deploy
         with:
-          ecr-url: ${{ secrets.ECR_TEAM_REPO_URL }}
+          ecr-region: ${{ vars.ECR_REGION }}
+          ecr-role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          ecr-repository: ${{ vars.ECR_REPOSITORY }}
           kube-cert: ${{ secrets.KUBE_PRODUCTION_CERT }}
           kube-token: ${{ secrets.KUBE_PRODUCTION_TOKEN }}
           kube-cluster: ${{ secrets.KUBE_PRODUCTION_CLUSTER }}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4166)

Use short-lived ECR credentials to build and deploy images as per this guide https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#migrating-to-short-lived-credentials-for-github-actions.

**TODO**

Move to a lifecycle policy for ECR images as we will no longer have the ability to run aws cli ecr commands/delete images with a script. See https://dsdmoj.atlassian.net/browse/AP-4178

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
