### PR TITLE
AP-4181: extract clients income from employment to results

### DIFF
--- a/app/models/concerns/hmrc_interface_resultable.rb
+++ b/app/models/concerns/hmrc_interface_resultable.rb
@@ -10,7 +10,7 @@ module HmrcInterfaceResultable
                                             || working_tax_credit_award_total_entitlements&.first
     end
 
-    # Sum all of "income/paye/paye":"income":["grossEarningsForNics"]:"inPayPeriod1"
+    # returns integer or zero
     def clients_income_from_employment
       gross_earnings_for_nics_in_pay_period_1&.sum
     end
@@ -35,9 +35,8 @@ module HmrcInterfaceResultable
 
     # returns array of hashes
     def child_tax_credit_awards
-      @child_tax_credit_awards ||= child_tax_credits
-        &.find_all { |el| el.key?("awards") }
-        &.flat_map { |el| el["awards"] }
+      @child_tax_credit_awards ||=
+        child_tax_credits&.all_hashes("awards")
     end
 
     # returns array of decimals
@@ -54,9 +53,8 @@ module HmrcInterfaceResultable
 
     # returns array of hashes
     def working_tax_credit_awards
-      @working_tax_credit_awards ||= working_tax_credits
-        &.find_all { |el| el.key?("awards") }
-        &.flat_map { |el| el["awards"] }
+      @working_tax_credit_awards ||=
+        working_tax_credits&.all_hashes("awards")
     end
 
     # returns array of decimals
@@ -78,17 +76,13 @@ module HmrcInterfaceResultable
 
     # returns array of hashes
     def gross_earnings_for_nics
-      key = "grossEarningsForNics"
-      @gross_earnings_for_nics ||= income
-        &.find_all { |el| el.key?(key) }
-        &.flat_map { |el| el[key] }
+      @gross_earnings_for_nics ||= income&.all_hashes("grossEarningsForNics")
     end
 
     # returns array of integers
     def gross_earnings_for_nics_in_pay_period_1
-      @gross_earnings_for_nics_in_pay_period_1 ||= gross_earnings_for_nics
-        &.find_all {|el| el.key?("inPayPeriod1") }
-        &.flat_map { |el| el["inPayPeriod1"] }
+      @gross_earnings_for_nics_in_pay_period_1 ||=
+        gross_earnings_for_nics&.all_hashes("inPayPeriod1")
     end
   end
 end

--- a/app/models/concerns/hmrc_interface_resultable.rb
+++ b/app/models/concerns/hmrc_interface_resultable.rb
@@ -20,46 +20,46 @@ module HmrcInterfaceResultable
       @error ||= data&.second&.fetch("error", nil)
     end
 
-    # returns array
+    # returns array of hashes
     def data
       @data ||= hmrc_interface_result.with_indifferent_access["data"]
     end
 
   private
 
-    # returns array
+    # returns array of hashes
     def child_tax_credits
       key = "benefits_and_credits/child_tax_credit/applications"
-      @child_tax_credits ||= data&.find { |el| el.key?(key) }&.fetch(key, nil)
+      @child_tax_credits ||= data&.fetch_first(key, nil)
     end
 
-    # returns array
+    # returns array of hashes
     def child_tax_credit_awards
       @child_tax_credit_awards ||= child_tax_credits
         &.find_all { |el| el.key?("awards") }
         &.flat_map { |el| el["awards"] }
     end
 
-    # returns array
+    # returns array of decimals
     def child_tax_credit_award_total_entitlements
       @child_tax_credit_award_total_entitlements ||=
         child_tax_credit_awards&.map { |el| el["totalEntitlement"] }
     end
 
-    # returns array
+    # returns array of hashes
     def working_tax_credits
       key = "benefits_and_credits/working_tax_credit/applications"
-      @working_tax_credits ||= data&.find { |el| el.key?(key) }&.fetch(key, nil)
+      @working_tax_credits ||= data&.fetch_first(key, nil)
     end
 
-    # returns array
+    # returns array of hashes
     def working_tax_credit_awards
       @working_tax_credit_awards ||= working_tax_credits
         &.find_all { |el| el.key?("awards") }
         &.flat_map { |el| el["awards"] }
     end
 
-    # returns array
+    # returns array of decimals
     def working_tax_credit_award_total_entitlements
       @working_tax_credit_award_total_entitlements ||=
         working_tax_credit_awards&.map { |el| el["totalEntitlement"] }
@@ -68,15 +68,15 @@ module HmrcInterfaceResultable
     # returns hash
     def income_paye_paye
       key = "income/paye/paye"
-      @income_paye_paye ||= data&.find { |el| el.key?(key) }&.fetch(key, nil)
+      @income_paye_paye ||= data&.fetch_first(key, nil)
     end
 
-    # returns array of objects
+    # returns array of hashes
     def income
       @income ||= income_paye_paye&.fetch("income", nil)
     end
 
-    # returns array of objects
+    # returns array of hashes
     def gross_earnings_for_nics
       key = "grossEarningsForNics"
       @gross_earnings_for_nics ||= income

--- a/app/models/concerns/hmrc_interface_resultable.rb
+++ b/app/models/concerns/hmrc_interface_resultable.rb
@@ -12,7 +12,7 @@ module HmrcInterfaceResultable
 
     # returns integer or zero
     def clients_income_from_employment
-      gross_earnings_for_nics_in_pay_period_1&.sum
+      @clients_income_from_employment ||= gross_earnings_for_nics_in_pay_period_1&.sum
     end
 
     # returns string or nil

--- a/app/services/submission_result_csv.rb
+++ b/app/services/submission_result_csv.rb
@@ -4,7 +4,11 @@ class SubmissionResultCsv
   attr_reader :submission
 
   def self.headers(original_headers = SubmissionRecord.members)
-    original_headers + [:status, :comment, :tax_credit_annual_award_amount, :uc_one_data, :uc_two_data]
+    original_headers + %i[status
+                          comment
+                          tax_credit_annual_award_amount
+                          clients_income_from_employment
+                          uc_one_data uc_two_data]
   end
 
   delegate :period_start_at,
@@ -25,7 +29,7 @@ class SubmissionResultCsv
   end
 
   def row
-    [
+    @row = [
       period_start_at.to_fs(:csv),
       period_end_at.to_fs(:csv),
       first_name,
@@ -35,9 +39,13 @@ class SubmissionResultCsv
       status,
       comment,
       tax_credit_annual_award_amount,
+      clients_income_from_employment,
       uc_one_data,
       uc_two_data,
     ]
+
+    raise StandardError, "mismatched header and row element size" if self.class.headers.size != @row.size
+    @row
   end
 
 private

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -3,3 +3,7 @@ Dir[Rails.root.join('lib/extensions/*.rb')].each { |file| require file }
 module Rails
   extend RailsModuleExtension
 end
+
+class Array
+  include ArrayExtension
+end

--- a/lib/extensions/array_extension.rb
+++ b/lib/extensions/array_extension.rb
@@ -1,0 +1,6 @@
+module ArrayExtension
+  def fetch_first(key, default = nil)
+    find { |el| el.key?(key) }&.fetch(key, default)
+  end
+end
+

--- a/lib/extensions/array_extension.rb
+++ b/lib/extensions/array_extension.rb
@@ -2,5 +2,10 @@ module ArrayExtension
   def fetch_first(key, default = nil)
     find { |el| el.key?(key) }&.fetch(key, default)
   end
+
+  def all_hashes(key)
+    find_all { |el| el.key?(key) }
+      &.flat_map { |el| el[key] }
+  end
 end
 

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -140,6 +140,32 @@ FactoryBot.define do
       end
     end
 
+    trait :with_use_case_one_income_paye do
+      status { :completed }
+      use_case { :one }
+      hmrc_interface_result do
+        {
+          "data" => [
+           { "use_case" => "use_case_one" },
+           { "income/paye/paye" => {
+                "income" => [
+                  {
+                    "grossEarningsForNics": {
+                      "inPayPeriod1": 333
+                    },
+                  },
+                  { "grossEarningsForNics": {
+                      "inPayPeriod1": 666
+                  },
+                },
+                ]
+              }
+            }
+          ]
+        }.as_json
+      end
+    end
+
     trait :with_completed_use_case_two_hmrc_interface_result do
       status { :completed }
       use_case { :two }

--- a/spec/models/concerns/hmrc_interface_resultable_spec.rb
+++ b/spec/models/concerns/hmrc_interface_resultable_spec.rb
@@ -25,13 +25,15 @@ RSpec.describe HmrcInterfaceResultable do
   end
 
   describe "#data" do
+    subject(:data) { instance.data }
+
     context "with symbols for keys" do
       let(:result) { { data: [ { use_case: "use_case_one" } ] } }
 
       it "returns the hash value for data with indifferent access" do
-        expect(instance.data).to be_an Array
-        expect(instance.data).to eql([{ "use_case" => "use_case_one" }])
-        expect(instance.data[0][:use_case]).to eql("use_case_one")
+        expect(data).to be_an Array
+        expect(data).to eql([{ "use_case" => "use_case_one" }])
+        expect(data[0][:use_case]).to eql("use_case_one")
       end
     end
 
@@ -39,20 +41,22 @@ RSpec.describe HmrcInterfaceResultable do
       let(:result) { { "data" => [ { "use_case" => "use_case_one" } ] } }
 
       it "returns the hash value for data with indifferent access" do
-        expect(instance.data).to be_an Array
-        expect(instance.data).to eql([{ "use_case" => "use_case_one" }])
-        expect(instance.data[0]["use_case"]).to eql("use_case_one")
+        expect(data).to be_an Array
+        expect(data).to eql([{ "use_case" => "use_case_one" }])
+        expect(data[0]["use_case"]).to eql("use_case_one")
       end
     end
 
     context "with no data key" do
       let(:result) { { not_this: [ { "use_case" => "use_case_one" } ] } }
 
-      it { expect(instance.data).to be_nil }
+      it { expect(data).to be_nil }
     end
   end
 
   describe "#error" do
+    subject(:error) { instance.error }
+
     context "when error exists" do
       let(:result) do
         {
@@ -63,24 +67,26 @@ RSpec.describe HmrcInterfaceResultable do
       end
 
       it "returns the string value for error" do
-        expect(instance.error).to eql("foobar")
+        expect(error).to eql("foobar")
       end
     end
 
     context "when error does not exist" do
       let(:result) { { data: [ { foo: "bar" } ] } }
 
-      it { expect(instance.error).to be_nil }
+      it { expect(error).to be_nil }
     end
 
     context "with no data key" do
       let(:result) { { foo: [ { bar: "baz" } ] } }
 
-      it { expect(instance.error).to be_nil }
+      it { expect(error).to be_nil }
     end
   end
 
   describe "#tax_credit_annual_award_amount" do
+    subject(:tax_credit_annual_award_amount) { instance.tax_credit_annual_award_amount }
+
     context "when working and child tax credits exist" do
       let(:result) do
          {
@@ -103,7 +109,7 @@ RSpec.describe HmrcInterfaceResultable do
       end
 
       it "returns the decimal value for the first child_tax_credit award" do
-        expect(instance.tax_credit_annual_award_amount).to be 9075.96
+        expect(tax_credit_annual_award_amount).to be 9075.96
       end
     end
 
@@ -123,7 +129,7 @@ RSpec.describe HmrcInterfaceResultable do
       end
 
       it "returns the decimal value for the first working_tax_credit award" do
-        expect(instance.tax_credit_annual_award_amount).to be 8075.96
+        expect(tax_credit_annual_award_amount).to be 8075.96
       end
     end
 
@@ -138,13 +144,124 @@ RSpec.describe HmrcInterfaceResultable do
         }
       end
 
-      it { expect(instance.tax_credit_annual_award_amount).to be_nil }
+      it { expect(tax_credit_annual_award_amount).to be_nil }
     end
 
     context "with no data key" do
       let(:result) { { foo: [ { bar: "baz" } ] } }
 
-      it { expect(instance.tax_credit_annual_award_amount).to be_nil }
+      it { expect(tax_credit_annual_award_amount).to be_nil }
+    end
+  end
+
+  describe "#clients_income_from_employment" do
+    subject(:clients_income_from_employment) { instance.clients_income_from_employment }
+
+    context "when multiple income exists" do
+      let(:result) do
+        {
+          "data" => [
+            { "use_case" => "use_case_one" },
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 433
+                    },
+                  },
+                  {
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 525
+                    },
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      it "returns the sum of all grossEarningsForNics#inPayPeriod1 values" do
+        expect(clients_income_from_employment).to be 958
+      end
+    end
+
+    context "when single income exists" do
+      let(:result) do
+        {
+          "data" => [
+            { "use_case" => "use_case_one" },
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 433
+                    },
+                  },
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      it "returns the single grossEarningsForNics#inPayPeriod1 value" do
+        expect(clients_income_from_employment).to be 433
+      end
+    end
+
+    context "when no income exists" do
+      let(:result) do
+        {
+          "data" => [
+            { "use_case" => "use_case_one" },
+            {
+              "income/paye/paye" => {
+                "income" => []
+              }
+            }
+          ]
+        }
+      end
+
+      it { expect(clients_income_from_employment).to be_zero }
+    end
+
+    context "when one is nil and one not" do
+      let(:result) do
+        {
+          "data" => [
+            { "use_case" => "use_case_one" },
+            {
+              "income/paye/paye" => {
+                "income" => [
+                  {
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 333
+                    },
+                  },
+                  {
+                    "grossEarningsForNics" => {
+                    },
+                  },
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      it "returns the single valid grossEarningsForNics#inPayPeriod1 value" do
+        expect(clients_income_from_employment).to be 333
+      end
+    end
+
+    context "with no data key" do
+      let(:result) { { foo: [ { bar: "baz" } ] } }
+
+      it { expect(clients_income_from_employment).to be_nil }
     end
   end
 end

--- a/spec/services/bulk_submission_result_writer_service_spec.rb
+++ b/spec/services/bulk_submission_result_writer_service_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe BulkSubmissionResultWriterService do
             .to(true)
 
         expected_content = <<~CSV
-          "period_start_date","period_end_date","first_name","last_name","date_of_birth","nino","status","comment","tax_credit_annual_award_amount","uc_one_data","uc_two_data"
-          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","[\n  {\n    "\"use_case\"": "\"use_case_one"\"\n  }\n]","[\n  {\n    "\"use_case\"": "\"use_case_two"\"\n  }\n]"
+          "period_start_date","period_end_date","first_name","last_name","date_of_birth","nino","status","comment","tax_credit_annual_award_amount","clients_income_from_employment","uc_one_data","uc_two_data"
+          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","","[\n  {\n    "\"use_case\"": "\"use_case_one"\"\n  }\n]","[\n  {\n    "\"use_case\"": "\"use_case_two"\"\n  }\n]"
         CSV
 
         expect(bulk_submission.result_file.download).to eql(expected_content)

--- a/spec/services/submission_result_csv_spec.rb
+++ b/spec/services/submission_result_csv_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe SubmissionResultCsv do
          status
          comment
          tax_credit_annual_award_amount
+         clients_income_from_employment
          uc_one_data
          uc_two_data]
     end
@@ -55,6 +56,7 @@ RSpec.describe SubmissionResultCsv do
           "completed",
           nil,
           nil,
+          nil,
           %([\n  {\n    "use_case": "use_case_one"\n  }\n]),
           %([\n  {\n    "use_case": "use_case_two"\n  }\n]),
         ]
@@ -73,8 +75,8 @@ RSpec.describe SubmissionResultCsv do
                bulk_submission:)
       end
 
-      it "includes most recent child tax credit award's total entitlement value" do
-        expect(row).to include(8075.96)
+      it "includes most recent child tax credit award's total entitlement value at position 9" do
+        expect(row[8]).to be 8075.96
       end
     end
 
@@ -86,8 +88,8 @@ RSpec.describe SubmissionResultCsv do
                bulk_submission:)
       end
 
-      it "includes most recent working tax credit awards total entitlement value" do
-        expect(row).to include(8075.96)
+      it "includes most recent working tax credit award's total entitlement value at position 9" do
+        expect(row[8]).to be 8075.96
       end
     end
 
@@ -99,8 +101,21 @@ RSpec.describe SubmissionResultCsv do
                bulk_submission:)
       end
 
-      it "includes most recent child tax credit awards total entitlement value" do
-        expect(row).to include(9075.96)
+      it "includes most recent child tax credit award's total entitlement value at position 9" do
+        expect(row[8]).to be 9075.96
+      end
+    end
+
+    context "with a completed submission with multiple income paye objects" do
+            let(:submission) do
+        create(:submission,
+               :for_john_doe,
+               :with_use_case_one_income_paye,
+               bulk_submission:)
+      end
+
+      it "includes sum of all income grossEarningsForNics#inPayPeriod1 values at position 10" do
+        expect(row[9]).to be 999
       end
     end
 
@@ -129,6 +144,7 @@ RSpec.describe SubmissionResultCsv do
           "JA123456D",
           "failed",
           "submitted client details could not be found in HMRC service",
+          nil,
           nil,
           %([\n  {\n    "use_case": "use_case_one",\n    "correlation_id": "an-hmrc-interface-submission-uuid"\n  },\n  {\n    "error": "submitted client details could not be found in HMRC service"\n  }\n]),
           %([\n  {\n    "use_case": "use_case_two",\n    "correlation_id": "an-hmrc-interface-submission-uuid"\n  },\n  {\n    "error": "submitted client details could not be found in HMRC service"\n  }\n]),
@@ -166,6 +182,7 @@ RSpec.describe SubmissionResultCsv do
           "JA123456D",
           "exhausted",
           "attempts to retrieve details for the individual were unsuccessful",
+          nil,
           nil,
           %({\n  "submission": "uc-one-hmrc-interface-submission-uuid",\n  "status": "processing",\n  "_links": [\n    {\n      "href": "http://www.example.com/api/v1/submission/result/uc-one-hmrc-interface-submission-uuid"\n    }\n  ]\n}),
           # TODO: handle failing test in which the keys are not coming back in order inserted


### PR DESCRIPTION
Extract data to required fields

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4181)

Populates the following fields in the results CSV

~~- [x] “Tax Credit Annual Award Amount”~~
- [x] “Client's Income from Employment” 
- [ ] “Clients national insurance contributions from employment”
- [ ] “Start date for Employment (only if employed in year of application)”
- [ ] “End date for Employment (only if employed in year of application)”
- [ ] “Client's Income from Self Employment”

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
