### PR TITLE
AP-4181: Add "Clients NI contributions from employment" field to results

### DIFF
--- a/app/models/concerns/hmrc_interface_resultable.rb
+++ b/app/models/concerns/hmrc_interface_resultable.rb
@@ -15,6 +15,11 @@ module HmrcInterfaceResultable
       @clients_income_from_employment ||= gross_earnings_for_nics_in_pay_period_1&.sum
     end
 
+    # returns decimal or zero
+    def clients_ni_contributions_from_employment
+      @clients_ni_contributions_from_employment ||= employee_nics_in_pay_period_1&.sum
+    end
+
     # returns string or nil
     def error
       @error ||= data&.second&.fetch("error", nil)
@@ -36,7 +41,7 @@ module HmrcInterfaceResultable
     # returns array of hashes
     def child_tax_credit_awards
       @child_tax_credit_awards ||=
-        child_tax_credits&.all_hashes("awards")
+        child_tax_credits&.fetch_all("awards")
     end
 
     # returns array of decimals
@@ -54,7 +59,7 @@ module HmrcInterfaceResultable
     # returns array of hashes
     def working_tax_credit_awards
       @working_tax_credit_awards ||=
-        working_tax_credits&.all_hashes("awards")
+        working_tax_credits&.fetch_all("awards")
     end
 
     # returns array of decimals
@@ -76,13 +81,24 @@ module HmrcInterfaceResultable
 
     # returns array of hashes
     def gross_earnings_for_nics
-      @gross_earnings_for_nics ||= income&.all_hashes("grossEarningsForNics")
+      @gross_earnings_for_nics ||= income&.fetch_all("grossEarningsForNics")
     end
 
     # returns array of integers
     def gross_earnings_for_nics_in_pay_period_1
       @gross_earnings_for_nics_in_pay_period_1 ||=
-        gross_earnings_for_nics&.all_hashes("inPayPeriod1")
+        gross_earnings_for_nics&.fetch_all("inPayPeriod1")
     end
+
+    # returns array of decimals
+    def employee_nics_in_pay_period_1
+      @employee_nics_in_pay_period_1 ||= employee_nics&.fetch_all("inPayPeriod1")
+    end
+
+    # returns array of hashes
+    def employee_nics
+      @employee_nics ||= income&.fetch_all("employeeNics")
+    end
+
   end
 end

--- a/app/models/concerns/hmrc_interface_resultable.rb
+++ b/app/models/concerns/hmrc_interface_resultable.rb
@@ -22,7 +22,7 @@ module HmrcInterfaceResultable
 
     # returns string or nil
     def error
-      @error ||= data&.second&.fetch("error", nil)
+      @error ||= data&.second&.fetch("error")
     end
 
     # returns array of hashes
@@ -34,14 +34,13 @@ module HmrcInterfaceResultable
 
     # returns array of hashes
     def child_tax_credits
-      key = "benefits_and_credits/child_tax_credit/applications"
-      @child_tax_credits ||= data&.fetch_first(key, nil)
+      @child_tax_credits ||=
+        data&.fetch_first("benefits_and_credits/child_tax_credit/applications")
     end
 
     # returns array of hashes
     def child_tax_credit_awards
-      @child_tax_credit_awards ||=
-        child_tax_credits&.fetch_all("awards")
+      @child_tax_credit_awards ||= child_tax_credits&.fetch_all("awards")
     end
 
     # returns array of decimals
@@ -52,14 +51,13 @@ module HmrcInterfaceResultable
 
     # returns array of hashes
     def working_tax_credits
-      key = "benefits_and_credits/working_tax_credit/applications"
-      @working_tax_credits ||= data&.fetch_first(key, nil)
+      @working_tax_credits ||=
+        data&.fetch_first("benefits_and_credits/working_tax_credit/applications")
     end
 
     # returns array of hashes
     def working_tax_credit_awards
-      @working_tax_credit_awards ||=
-        working_tax_credits&.fetch_all("awards")
+      @working_tax_credit_awards ||= working_tax_credits&.fetch_all("awards")
     end
 
     # returns array of decimals
@@ -70,13 +68,12 @@ module HmrcInterfaceResultable
 
     # returns hash
     def income_paye_paye
-      key = "income/paye/paye"
-      @income_paye_paye ||= data&.fetch_first(key, nil)
+      @income_paye_paye ||= data&.fetch_first("income/paye/paye")
     end
 
     # returns array of hashes
     def income
-      @income ||= income_paye_paye&.fetch("income", nil)
+      @income ||= income_paye_paye&.fetch("income")
     end
 
     # returns array of hashes

--- a/app/services/submission_result_csv.rb
+++ b/app/services/submission_result_csv.rb
@@ -8,7 +8,9 @@ class SubmissionResultCsv
                           comment
                           tax_credit_annual_award_amount
                           clients_income_from_employment
-                          uc_one_data uc_two_data]
+                          clients_ni_contributions_from_employment
+                          uc_one_data
+                          uc_two_data]
   end
 
   delegate :period_start_at,
@@ -40,6 +42,7 @@ class SubmissionResultCsv
       comment,
       tax_credit_annual_award_amount,
       clients_income_from_employment,
+      clients_ni_contributions_from_employment,
       uc_one_data,
       uc_two_data,
     ]

--- a/lib/extensions/array_extension.rb
+++ b/lib/extensions/array_extension.rb
@@ -3,7 +3,7 @@ module ArrayExtension
     find { |el| el.key?(key) }&.fetch(key, default)
   end
 
-  def all_hashes(key)
+  def fetch_all(key)
     find_all { |el| el.key?(key) }
       &.flat_map { |el| el[key] }
   end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -140,7 +140,7 @@ FactoryBot.define do
       end
     end
 
-    trait :with_use_case_one_income_paye do
+    trait :with_use_case_one_gross_income_for_nics do
       status { :completed }
       use_case { :one }
       hmrc_interface_result do
@@ -150,14 +150,43 @@ FactoryBot.define do
            { "income/paye/paye" => {
                 "income" => [
                   {
-                    "grossEarningsForNics": {
-                      "inPayPeriod1": 333
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 333
                     },
                   },
-                  { "grossEarningsForNics": {
-                      "inPayPeriod1": 666
+                  { "grossEarningsForNics" => {
+                      "inPayPeriod1" => 666
+                    },
                   },
-                },
+                ]
+              }
+            }
+          ]
+        }.as_json
+      end
+    end
+
+    # NOTE: reflects real data where some income entries have no `employeeNics`
+    trait :with_use_case_one_employee_nics do
+      status { :completed }
+      use_case { :one }
+      hmrc_interface_result do
+        {
+          "data" => [
+           { "use_case" => "use_case_one" },
+           { "income/paye/paye" => {
+                "income" => [
+                  {
+                    "employeeNics" => {
+                      "inPayPeriod1" => 222.22
+                    },
+                  },
+                  { "employeeNics" => {
+                      "inPayPeriod1" => 444.44
+                    },
+                  },
+                  {
+                  },
                 ]
               }
             }

--- a/spec/fixtures/files/results/hmrc_interface_successful_result_response_body_with_income_paye.json
+++ b/spec/fixtures/files/results/hmrc_interface_successful_result_response_body_with_income_paye.json
@@ -1,0 +1,214 @@
+{
+  "submission": "fake-hmrc-interface-submission-id",
+  "status": "completed",
+  "data": [
+    {
+      "use_case": "use_case_one",
+      "correlation_id": "fake-hmrc-interface-submission-id"
+    },
+    {
+      "individuals/matching/individual": {
+        "nino": "XY123456D",
+        "lastName": "lname",
+        "firstName": "fname",
+        "dateOfBirth": "1985-01-01"
+      }
+    },
+    {
+      "income/paye/paye": {
+        "income": [
+          {
+            "taxYear": "21-22",
+            "taxablePay": 1431.07,
+            "paymentDate": "2022-04-05",
+            "employeeNics": {
+              "ytd1": 165.21,
+              "inPayPeriod1": 45.97
+            },
+            "payFrequency": "M1",
+            "monthPayNumber": 12,
+            "totalTaxToDate": 0,
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 3867.26,
+            "totalEmployerNics": {
+              "ytd1": 270.03,
+              "inPayPeriod1": 92.88
+            },
+            "grossEarningsForNics": {
+              "inPayPeriod1": 1431.07
+            },
+            "taxDeductedOrRefunded": 0,
+            "employeePensionContribs": {
+              "notPaid": 36.45,
+              "notPaidYTD": 97.32
+            }
+          },
+          {
+            "taxYear": "21-22",
+            "taxablePay": 2041.67,
+            "paymentDate": "2022-03-03",
+            "employeeNics": {
+              "ytd1": 119.24,
+              "inPayPeriod1": 119.24
+            },
+            "payFrequency": "M1",
+            "monthPayNumber": 11,
+            "totalTaxToDate": 0,
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 2436.19,
+            "totalEmployerNics": {
+              "ytd1": 177.15,
+              "inPayPeriod1": 177.15
+            },
+            "grossEarningsForNics": {
+              "inPayPeriod1": 2041.67
+            },
+            "taxDeductedOrRefunded": 0,
+            "employeePensionContribs": {
+              "notPaid": 60.87,
+              "notPaidYTD": 60.87
+            }
+          },
+          {
+            "taxYear": "21-22",
+            "taxablePay": 394.52,
+            "paymentDate": "2022-02-03",
+            "payFrequency": "M1",
+            "monthPayNumber": 10,
+            "totalTaxToDate": 0,
+            "paidHoursWorked": "D",
+            "taxablePayToDate": 394.52,
+            "grossEarningsForNics": {
+              "inPayPeriod1": 394.52
+            },
+            "taxDeductedOrRefunded": 0
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/selfAssessment": {
+        "taxReturns": [
+
+        ],
+        "registrations": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/pensions_and_state_benefits/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/source/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/employments/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/additional_information/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/partnerships/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/uk_properties/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/foreign/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/further_details/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/interests_and_dividends/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/other/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/summary/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "income/sa/trusts/selfAssessment": {
+        "taxReturns": [
+
+        ]
+      }
+    },
+    {
+      "employments/paye/employments": [
+        {
+          "endDate": "2099-12-31",
+          "startDate": "2023-01-26"
+        },
+        {
+          "endDate": "2022-11-11",
+          "startDate": "2022-09-11"
+        }
+      ]
+    },
+    {
+      "benefits_and_credits/working_tax_credit/applications": [
+        {
+          "awards": [
+
+          ]
+        }
+      ]
+    },
+    {
+      "benefits_and_credits/child_tax_credit/applications": [
+        {
+          "awards": [
+
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/models/concerns/hmrc_interface_resultable_spec.rb
+++ b/spec/models/concerns/hmrc_interface_resultable_spec.rb
@@ -264,4 +264,105 @@ RSpec.describe HmrcInterfaceResultable do
       it { expect(clients_income_from_employment).to be_nil }
     end
   end
+
+  describe "#clients_ni_contributions_from_employment" do
+    subject(:clients_ni_contributions_from_employment) { instance.clients_ni_contributions_from_employment }
+
+    context "when multiple income exists" do
+      let(:result) do
+        {
+          "data" => [
+           { "income/paye/paye" => {
+                "income" => [
+                  {
+                    "employeeNics" => {
+                      "inPayPeriod1" => 222.22
+                    },
+                  },
+                  { "employeeNics" => {
+                      "inPayPeriod1" => 444.44
+                    },
+                  },
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      it "returns the sum of all employeeNics#inPayPeriod1 values" do
+        expect(clients_ni_contributions_from_employment).to be 666.66
+      end
+    end
+
+    context "when single income exists" do
+      let(:result) do
+        {
+          "data" => [
+           { "income/paye/paye" => {
+                "income" => [
+                  {
+                    "employeeNics" => {
+                      "inPayPeriod1" => 222.22
+                    },
+                  },
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      it "returns the single employeeNics#inPayPeriod1 value" do
+        expect(clients_ni_contributions_from_employment).to be 222.22
+      end
+    end
+
+    context "when no income exists" do
+      let(:result) do
+        {
+          "data" => [
+            {
+              "income/paye/paye" => {
+                "income" => []
+              }
+            }
+          ]
+        }
+      end
+
+      it { expect(clients_ni_contributions_from_employment).to be_zero }
+    end
+
+    # NOTE: real data seen that reflects this
+    context "when one income entry has employeeNics and one does not" do
+      let(:result) do
+        {
+          "data" => [
+           { "income/paye/paye" => {
+                "income" => [
+                  { "employeeNics" => {
+                      "inPayPeriod1" => 444.44
+                    },
+                  },
+                  {
+                  },
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      it "returns the single valid employeeNics#inPayPeriod1 value" do
+        expect(clients_ni_contributions_from_employment).to be 444.44
+      end
+    end
+
+    context "with no data key" do
+      let(:result) { { foo: [ { bar: "baz" } ] } }
+
+      it { expect(clients_ni_contributions_from_employment).to be_nil }
+    end
+  end
 end

--- a/spec/services/bulk_submission_result_writer_service_spec.rb
+++ b/spec/services/bulk_submission_result_writer_service_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe BulkSubmissionResultWriterService do
             .to(true)
 
         expected_content = <<~CSV
-          "period_start_date","period_end_date","first_name","last_name","date_of_birth","nino","status","comment","tax_credit_annual_award_amount","clients_income_from_employment","uc_one_data","uc_two_data"
-          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","","[\n  {\n    "\"use_case\"": "\"use_case_one"\"\n  }\n]","[\n  {\n    "\"use_case\"": "\"use_case_two"\"\n  }\n]"
+          "period_start_date","period_end_date","first_name","last_name","date_of_birth","nino","status","comment","tax_credit_annual_award_amount","clients_income_from_employment","clients_ni_contributions_from_employment","uc_one_data","uc_two_data"
+          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","","","[\n  {\n    "\"use_case\"": "\"use_case_one"\"\n  }\n]","[\n  {\n    "\"use_case\"": "\"use_case_two"\"\n  }\n]"
         CSV
 
         expect(bulk_submission.result_file.download).to eql(expected_content)

--- a/spec/services/submission_result_csv_spec.rb
+++ b/spec/services/submission_result_csv_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe SubmissionResultCsv do
          comment
          tax_credit_annual_award_amount
          clients_income_from_employment
+         clients_ni_contributions_from_employment
          uc_one_data
          uc_two_data]
     end
@@ -54,6 +55,7 @@ RSpec.describe SubmissionResultCsv do
           "2001-07-21",
           "JA123456D",
           "completed",
+          nil,
           nil,
           nil,
           nil,
@@ -106,16 +108,29 @@ RSpec.describe SubmissionResultCsv do
       end
     end
 
-    context "with a completed submission with multiple income paye objects" do
-            let(:submission) do
+    context "with a completed submission with multiple income paye grossEarningsForNics hashes" do
+      let(:submission) do
         create(:submission,
                :for_john_doe,
-               :with_use_case_one_income_paye,
+               :with_use_case_one_gross_income_for_nics,
                bulk_submission:)
       end
 
       it "includes sum of all income grossEarningsForNics#inPayPeriod1 values at position 10" do
         expect(row[9]).to be 999
+      end
+    end
+
+    context "with a completed submission with multiple income paye employeeNics hashes" do
+      let(:submission) do
+        create(:submission,
+               :for_john_doe,
+               :with_use_case_one_employee_nics,
+               bulk_submission:)
+      end
+
+      it "includes sum of all income employeeNics#inPayPeriod1 values at position 11" do
+        expect(row[10]).to be 666.66
       end
     end
 
@@ -144,6 +159,7 @@ RSpec.describe SubmissionResultCsv do
           "JA123456D",
           "failed",
           "submitted client details could not be found in HMRC service",
+          nil,
           nil,
           nil,
           %([\n  {\n    "use_case": "use_case_one",\n    "correlation_id": "an-hmrc-interface-submission-uuid"\n  },\n  {\n    "error": "submitted client details could not be found in HMRC service"\n  }\n]),
@@ -182,6 +198,7 @@ RSpec.describe SubmissionResultCsv do
           "JA123456D",
           "exhausted",
           "attempts to retrieve details for the individual were unsuccessful",
+          nil,
           nil,
           nil,
           %({\n  "submission": "uc-one-hmrc-interface-submission-uuid",\n  "status": "processing",\n  "_links": [\n    {\n      "href": "http://www.example.com/api/v1/submission/result/uc-one-hmrc-interface-submission-uuid"\n    }\n  ]\n}),


### PR DESCRIPTION

## What
Extract data to required fields

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4181)

Populates the following fields in the results CSV

~~- [x] “Tax Credit Annual Award Amount”~~
~~- [x] “Client's Income from Employment”~~
- [x] “Clients national insurance contributions from employment”
- [ ] “Start date for Employment (only if employed in year of application)”
- [ ] “End date for Employment (only if employed in year of application)”
- [ ] “Client's Income from Self Employment”

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
