### PR TITLE
AP-4181: Add "Most recent payment" to results file

### DIFF
--- a/app/models/concerns/hmrc_interface_resultable.rb
+++ b/app/models/concerns/hmrc_interface_resultable.rb
@@ -20,9 +20,19 @@ module HmrcInterfaceResultable
       @clients_ni_contributions_from_employment ||= employee_nics_in_pay_period_1&.sum
     end
 
+    # TODO: placeholder for subsequent PR as this maybe one OR two fields based on requested caseworker feedback
+    def start_and_end_date_for_employment
+    end
+
+    def most_recent_payment
+      return unless payment_dates&.first && gross_earnings_for_nics_in_pay_period_1&.first
+
+      @most_recent_payment ||= "#{payment_dates&.first}: #{gross_earnings_for_nics_in_pay_period_1&.first}"
+    end
+
     # returns string or nil
     def error
-      @error ||= data&.second&.fetch("error")
+      @error ||= data&.second&.fetch("error", nil)
     end
 
     # returns array of hashes
@@ -73,7 +83,7 @@ module HmrcInterfaceResultable
 
     # returns array of hashes
     def income
-      @income ||= income_paye_paye&.fetch("income")
+      @income ||= income_paye_paye&.fetch("income", nil)
     end
 
     # returns array of hashes
@@ -81,7 +91,7 @@ module HmrcInterfaceResultable
       @gross_earnings_for_nics ||= income&.fetch_all("grossEarningsForNics")
     end
 
-    # returns array of integers
+    # returns array of decimals
     def gross_earnings_for_nics_in_pay_period_1
       @gross_earnings_for_nics_in_pay_period_1 ||=
         gross_earnings_for_nics&.fetch_all("inPayPeriod1")
@@ -97,5 +107,9 @@ module HmrcInterfaceResultable
       @employee_nics ||= income&.fetch_all("employeeNics")
     end
 
+    # returns array of string dates
+    def payment_dates
+      income&.fetch_all("paymentDate")
+    end
   end
 end

--- a/app/services/submission_result_csv.rb
+++ b/app/services/submission_result_csv.rb
@@ -9,6 +9,8 @@ class SubmissionResultCsv
                           tax_credit_annual_award_amount
                           clients_income_from_employment
                           clients_ni_contributions_from_employment
+                          start_and_end_date_for_employment
+                          most_recent_payment
                           uc_one_data
                           uc_two_data]
   end
@@ -43,6 +45,8 @@ class SubmissionResultCsv
       tax_credit_annual_award_amount,
       clients_income_from_employment,
       clients_ni_contributions_from_employment,
+      start_and_end_date_for_employment,
+      most_recent_payment,
       uc_one_data,
       uc_two_data,
     ]

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -150,12 +150,15 @@ FactoryBot.define do
            { "income/paye/paye" => {
                 "income" => [
                   {
+                    "paymentDate" => "2022-03-17",
                     "grossEarningsForNics" => {
-                      "inPayPeriod1" => 333
+                      "inPayPeriod1" => 333.33
                     },
                   },
-                  { "grossEarningsForNics" => {
-                      "inPayPeriod1" => 666
+                  {
+                    "paymentDate" => "2022-02-20",
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 666.66
                     },
                   },
                 ]

--- a/spec/services/bulk_submission_result_writer_service_spec.rb
+++ b/spec/services/bulk_submission_result_writer_service_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe BulkSubmissionResultWriterService do
             .to(true)
 
         expected_content = <<~CSV
-          "period_start_date","period_end_date","first_name","last_name","date_of_birth","nino","status","comment","tax_credit_annual_award_amount","clients_income_from_employment","clients_ni_contributions_from_employment","uc_one_data","uc_two_data"
-          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","","","[\n  {\n    "\"use_case\"": "\"use_case_one"\"\n  }\n]","[\n  {\n    "\"use_case\"": "\"use_case_two"\"\n  }\n]"
+          "period_start_date","period_end_date","first_name","last_name","date_of_birth","nino","status","comment","tax_credit_annual_award_amount","clients_income_from_employment","clients_ni_contributions_from_employment","start_and_end_date_for_employment","most_recent_payment","uc_one_data","uc_two_data"
+          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","","","","","[\n  {\n    "\"use_case\"": "\"use_case_one"\"\n  }\n]","[\n  {\n    "\"use_case\"": "\"use_case_two"\"\n  }\n]"
         CSV
 
         expect(bulk_submission.result_file.download).to eql(expected_content)

--- a/spec/services/submission_result_csv_spec.rb
+++ b/spec/services/submission_result_csv_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe SubmissionResultCsv do
          tax_credit_annual_award_amount
          clients_income_from_employment
          clients_ni_contributions_from_employment
+         start_and_end_date_for_employment
+         most_recent_payment
          uc_one_data
          uc_two_data]
     end
@@ -55,6 +57,8 @@ RSpec.describe SubmissionResultCsv do
           "2001-07-21",
           "JA123456D",
           "completed",
+          nil,
+          nil,
           nil,
           nil,
           nil,
@@ -117,7 +121,7 @@ RSpec.describe SubmissionResultCsv do
       end
 
       it "includes sum of all income grossEarningsForNics#inPayPeriod1 values at position 10" do
-        expect(row[9]).to be 999
+        expect(row[9]).to be 999.99
       end
     end
 
@@ -131,6 +135,20 @@ RSpec.describe SubmissionResultCsv do
 
       it "includes sum of all income employeeNics#inPayPeriod1 values at position 11" do
         expect(row[10]).to be 666.66
+      end
+    end
+
+    context "with a completed submission with multiple income paye paymentDate and grossEarningsForNics hashes" do
+      let(:submission) do
+        create(:submission,
+               :for_john_doe,
+               :with_use_case_one_gross_income_for_nics,
+               bulk_submission:)
+      end
+
+      # NOTE: may need to move to position 14 (index 13)
+      it "includes string built from latest paymentDate and grossEarningsForNics#inPayPeriod1 value at position 13" do
+        expect(row[12]).to eql("2022-03-17: 333.33")
       end
     end
 
@@ -159,6 +177,8 @@ RSpec.describe SubmissionResultCsv do
           "JA123456D",
           "failed",
           "submitted client details could not be found in HMRC service",
+          nil,
+          nil,
           nil,
           nil,
           nil,
@@ -198,6 +218,8 @@ RSpec.describe SubmissionResultCsv do
           "JA123456D",
           "exhausted",
           "attempts to retrieve details for the individual were unsuccessful",
+          nil,
+          nil,
           nil,
           nil,
           nil,


### PR DESCRIPTION
## What
Extract data to required fields

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4181)

Populates the following fields in the results CSV

~~- [x] “Tax Credit Annual Award Amount”~~
~~- [x] “Client's Income from Employment”~~
~~- [x] “Clients national insurance contributions from employment”~~
- [ ] “Start date for Employment (only if employed in year of application)”
- [ ] “End date for Employment (only if employed in year of application)”
- [x] “Most recent payment amount”
- [ ] “Client's Income from Self Employment”

Inline with caseworker request this returns the
most recent/top payment amount and payment date
as a string, for example:

"2022-04-05: 1111.11"

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
