### PR TITLE
AP-4181: remove redundant separate child and working tax credit examples

### DIFF
--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -80,42 +80,6 @@ FactoryBot.define do
       hmrc_interface_result { { data: [ use_case: "use_case_one" ] }.as_json }
     end
 
-    trait :with_use_case_one_child_tax_credit do
-      status { :completed }
-      use_case { :one }
-      hmrc_interface_result do
-        {
-          "data" => [
-           { "use_case" => "use_case_one" },
-           { "benefits_and_credits/child_tax_credit/applications"=>
-               [{ "awards"=>
-                  [{ "payments"=>[],
-                     "totalEntitlement"=>8075.96 },
-                   { "payments"=>[],
-                     "totalEntitlement"=>8008.07 }] }] }
-          ]
-        }.as_json
-      end
-    end
-
-    trait :with_use_case_one_working_tax_credit do
-      status { :completed }
-      use_case { :one }
-      hmrc_interface_result do
-        {
-          "data" => [
-           { "use_case" => "use_case_one" },
-           { "benefits_and_credits/working_tax_credit/applications"=>
-               [{ "awards"=>
-                  [{ "payments"=>[],
-                     "totalEntitlement"=>8075.96 },
-                   { "payments"=>[],
-                     "totalEntitlement"=>8008.07 }] }] }
-          ]
-        }.as_json
-      end
-    end
-
     trait :with_use_case_one_child_and_working_tax_credit do
       status { :completed }
       use_case { :one }

--- a/spec/services/submission_result_csv_spec.rb
+++ b/spec/services/submission_result_csv_spec.rb
@@ -73,32 +73,6 @@ RSpec.describe SubmissionResultCsv do
       end
     end
 
-    context "with a completed submission with multiple child tax credit awards" do
-      let(:submission) do
-        create(:submission,
-               :for_john_doe,
-               :with_use_case_one_child_tax_credit,
-               bulk_submission:)
-      end
-
-      it "includes most recent child tax credit award's total entitlement value at position 9" do
-        expect(row[8]).to be 8075.96
-      end
-    end
-
-    context "with a completed submission with multiple working tax credit awards" do
-      let(:submission) do
-        create(:submission,
-               :for_john_doe,
-               :with_use_case_one_working_tax_credit,
-               bulk_submission:)
-      end
-
-      it "includes most recent working tax credit award's total entitlement value at position 9" do
-        expect(row[8]).to be 8075.96
-      end
-    end
-
     context "with a completed submission with both child and working tax credit awards" do
       let(:submission) do
         create(:submission,


### PR DESCRIPTION
## What
Remove redundant separate working and child taxt credit examples

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4181)

Already covered by `hmrc_interface_resultable_spec.rb`

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
