### PR TITLE
AP-4181: Add "Client's Income from Self Employment" to result file

### DIFF
--- a/app/services/submission_result_csv.rb
+++ b/app/services/submission_result_csv.rb
@@ -11,6 +11,7 @@ class SubmissionResultCsv
                           clients_ni_contributions_from_employment
                           start_and_end_dates_for_employments
                           most_recent_payment
+                          clients_income_from_self_employment
                           uc_one_data
                           uc_two_data]
   end
@@ -47,6 +48,7 @@ class SubmissionResultCsv
       clients_ni_contributions_from_employment,
       start_and_end_dates_for_employments,
       most_recent_payment,
+      clients_income_from_self_employment,
       uc_one_data,
       uc_two_data,
     ]

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -170,19 +170,61 @@ FactoryBot.define do
             "data" => [
               { "use_case" => "use_case_one" },
               {
-                "employments/paye/employments": [
+                "employments/paye/employments" => [
                   {
-                    "endDate": "2099-12-31",
-                    "startDate": "2023-01-26"
+                    "endDate" => "2099-12-31",
+                    "startDate" => "2023-01-26"
                   },
                   {
-                    "endDate": "2022-11-11",
-                    "startDate": "2022-09-11"
+                    "endDate" => "2022-11-11",
+                    "startDate" => "2022-09-11"
                   }
                 ]
               },
             ]
           }.as_json
+      end
+    end
+
+    trait :with_use_case_one_self_assessment_summary do
+      status { :completed }
+      use_case { :one }
+      hmrc_interface_result do
+        {
+          "data" => [
+            { "use_case" => "use_case_one" },
+            {
+              "income/sa/summary/selfAssessment" => {
+                "taxReturns" => [
+                  {
+                    "taxYear" => "2019-20",
+                    "summary" => [
+                      {
+                        "totalIncome" => 6487
+                      }
+                    ]
+                  },
+                  {
+                    "taxYear" => "2020-21",
+                    "summary" => [
+                      {
+                        "totalIncome" => 7995
+                      }
+                    ]
+                  },
+                  {
+                    "taxYear" => "2021-22",
+                    "summary" => [
+                      {
+                        "totalIncome" => 6824
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+          ]
+        }.as_json
       end
     end
 

--- a/spec/fixtures/files/results/hmrc_interface_successful_result_response_body_with_self_assessment_summary.json
+++ b/spec/fixtures/files/results/hmrc_interface_successful_result_response_body_with_self_assessment_summary.json
@@ -1,0 +1,799 @@
+{
+  "submission": "fake-hmrc-interface-submission-id",
+  "status": "completed",
+  "data": [
+    {
+      "correlation_id": "",
+      "use_case": "use_case_one"
+    },
+    {
+      "individuals/matching/individual": {
+        "firstName": "fname",
+        "lastName": "lname",
+        "nino": "XY123456D",
+        "dateOfBirth": "1985-01-01"
+      }
+    },
+    {
+      "income/paye/paye": {
+        "income": []
+      }
+    },
+    {
+      "income/sa/selfAssessment": {
+        "registrations": [
+          {
+            "registrationDate": "2015-03-18"
+          },
+          {
+            "registrationDate": "2015-03-18"
+          },
+          {
+            "registrationDate": "2015-03-18"
+          }
+        ],
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "submissions": []
+          },
+          {
+            "taxYear": "2020-21",
+            "submissions": []
+          },
+          {
+            "taxYear": "2021-22",
+            "submissions": []
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/pensions_and_state_benefits/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "pensionsAndStateBenefits": [
+              {
+                "totalIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "pensionsAndStateBenefits": [
+              {
+                "totalIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "pensionsAndStateBenefits": [
+              {
+                "totalIncome": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/employments/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "employments": [
+              {
+                "employmentIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "employments": [
+              {
+                "employmentIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "employments": [
+              {
+                "employmentIncome": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/additional_information/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "additionalInformation": [
+              {
+                "gainsOnLifePolicies": 0,
+                "sharesOptionsIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "additionalInformation": [
+              {
+                "gainsOnLifePolicies": 0,
+                "sharesOptionsIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "additionalInformation": [
+              {
+                "gainsOnLifePolicies": 0,
+                "sharesOptionsIncome": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/partnerships/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "partnerships": [
+              {
+                "partnershipProfit": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "partnerships": [
+              {
+                "partnershipProfit": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "partnerships": [
+              {
+                "partnershipProfit": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/uk_properties/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "ukProperties": [
+              {
+                "totalProfit": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "ukProperties": [
+              {
+                "totalProfit": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "ukProperties": [
+              {
+                "totalProfit": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/foreign/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "foreign": [
+              {
+                "foreignIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "foreign": [
+              {
+                "foreignIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "foreign": [
+              {
+                "foreignIncome": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/further_details/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "furtherDetails": [
+              {
+                "turnover": 8400,
+                "deducts": {
+                  "totalBusExpenses": 1913
+                }
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "furtherDetails": [
+              {
+                "turnover": 5670,
+                "deducts": {
+                  "totalBusExpenses": 1866
+                }
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "furtherDetails": [
+              {
+                "turnover": 7295,
+                "deducts": {
+                  "totalBusExpenses": 3307
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/interests_and_dividends/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "interestsAndDividends": [
+              {
+                "ukInterestsIncome": 0,
+                "foreignDividendsIncome": 0,
+                "ukDividendsIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "interestsAndDividends": [
+              {
+                "ukInterestsIncome": 0,
+                "foreignDividendsIncome": 0,
+                "ukDividendsIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "interestsAndDividends": [
+              {
+                "ukInterestsIncome": 0,
+                "foreignDividendsIncome": 0,
+                "ukDividendsIncome": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/other/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "other": [
+              {
+                "otherIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "other": [
+              {
+                "otherIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "other": [
+              {
+                "otherIncome": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/summary/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "summary": [
+              {
+                "totalIncome": 6487
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "summary": [
+              {
+                "totalIncome": 7995
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "summary": [
+              {
+                "totalIncome": 6824
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "income/sa/trusts/selfAssessment": {
+        "taxReturns": [
+          {
+            "taxYear": "2019-20",
+            "trusts": [
+              {
+                "trustIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2020-21",
+            "trusts": [
+              {
+                "trustIncome": 0
+              }
+            ]
+          },
+          {
+            "taxYear": "2021-22",
+            "trusts": [
+              {
+                "trustIncome": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "employments/paye/employments": []
+    },
+    {
+      "benefits_and_credits/working_tax_credit/applications": [
+      ]
+    },
+    {
+      "benefits_and_credits/child_tax_credit/applications": [
+      ]
+    }
+  ]
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/spec/services/bulk_submission_result_writer_service_spec.rb
+++ b/spec/services/bulk_submission_result_writer_service_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe BulkSubmissionResultWriterService do
             .to(true)
 
         expected_content = <<~CSV
-          "period_start_date","period_end_date","first_name","last_name","date_of_birth","nino","status","comment","tax_credit_annual_award_amount","clients_income_from_employment","clients_ni_contributions_from_employment","start_and_end_dates_for_employments","most_recent_payment","uc_one_data","uc_two_data"
-          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","","","","","[\n  {\n    "\"use_case\"": "\"use_case_one"\"\n  }\n]","[\n  {\n    "\"use_case\"": "\"use_case_two"\"\n  }\n]"
+          "period_start_date","period_end_date","first_name","last_name","date_of_birth","nino","status","comment","tax_credit_annual_award_amount","clients_income_from_employment","clients_ni_contributions_from_employment","start_and_end_dates_for_employments","most_recent_payment","clients_income_from_self_employment","uc_one_data","uc_two_data"
+          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","","","","","","[\n  {\n    "\"use_case\"": "\"use_case_one"\"\n  }\n]","[\n  {\n    "\"use_case\"": "\"use_case_two"\"\n  }\n]"
         CSV
 
         expect(bulk_submission.result_file.download).to eql(expected_content)

--- a/spec/services/submission_result_csv_spec.rb
+++ b/spec/services/submission_result_csv_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe SubmissionResultCsv do
          clients_ni_contributions_from_employment
          start_and_end_dates_for_employments
          most_recent_payment
+         clients_income_from_self_employment
          uc_one_data
          uc_two_data]
     end
@@ -57,6 +58,7 @@ RSpec.describe SubmissionResultCsv do
           "2001-07-21",
           "JA123456D",
           "completed",
+          nil,
           nil,
           nil,
           nil,
@@ -138,6 +140,19 @@ RSpec.describe SubmissionResultCsv do
       end
     end
 
+    context "with a completed submission with multiple self assessment taxReturn hashes" do
+      let(:submission) do
+        create(:submission,
+               :for_john_doe,
+               :with_use_case_one_self_assessment_summary,
+               bulk_submission:)
+      end
+
+      it "includes string built from all self assessment summary taxReturns values at position 14" do
+        expect(row[13]).to eql("2019-20: 6487\n2020-21: 7995\n2021-22: 6824")
+      end
+    end
+
     context "with a failed submission" do
       before do
         create(:submission,
@@ -163,6 +178,7 @@ RSpec.describe SubmissionResultCsv do
           "JA123456D",
           "failed",
           "submitted client details could not be found in HMRC service",
+          nil,
           nil,
           nil,
           nil,
@@ -204,6 +220,7 @@ RSpec.describe SubmissionResultCsv do
           "JA123456D",
           "exhausted",
           "attempts to retrieve details for the individual were unsuccessful",
+          nil,
           nil,
           nil,
           nil,


### PR DESCRIPTION
## What
Extract data to required fields

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4181)

Populates the following fields in the results CSV

~~- [x] “Tax Credit Annual Award Amount”~~
~~- [x] “Client's Income from Employment”~~
~~- [x] “Clients national insurance contributions from employment”~~
~~- [x] “Most recent payment amount”~~
~~- [x] “Start and End dates for Employment”~~
- [x] “Client's Income from Self Employment”

Final field that case workers have asked for in an agreed format -
a multiline string with tax year and total income, as below

```
2019-20: 4487
2020-21: 5935
2021-22: 6722
```

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
