### PR TITLE
Specify doorkeeper scopes which we want access to

### DIFF
--- a/config/initializers/hmrc_interface.rb
+++ b/config/initializers/hmrc_interface.rb
@@ -4,6 +4,7 @@ HmrcInterface.configure do |config|
   config.client_id = ENV.fetch("HMRC_INTERFACE_UID", nil)
   config.client_secret = ENV.fetch("HMRC_INTERFACE_SECRET", nil)
   config.host = ENV.fetch("HMRC_INTERFACE_HOST", nil)
+  config.scopes = %i[use_case_one use_case_two]
   config.logger = Rails.logger
 end
 

--- a/lib/hmrc_interface/client.rb
+++ b/lib/hmrc_interface/client.rb
@@ -42,7 +42,7 @@ private
     end
 
     def new_access_token
-      oauth_client.client_credentials.get_token
+      oauth_client.client_credentials.get_token(scopes: "use_case_one,use_case_two")
     end
 
     def fake_bearer_token

--- a/lib/hmrc_interface/client.rb
+++ b/lib/hmrc_interface/client.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 module HmrcInterface
   class Client
     delegate :configuration, :config, to: HmrcInterface
-    delegate :host, to: :configuration
+    delegate :host, :scopes, to: :configuration
 
     attr_reader :connection
 
@@ -42,7 +42,7 @@ private
     end
 
     def new_access_token
-      oauth_client.client_credentials.get_token(scopes: "use_case_one,use_case_two")
+      oauth_client.client_credentials.get_token(scopes:)
     end
 
     def fake_bearer_token

--- a/lib/hmrc_interface/configuration.rb
+++ b/lib/hmrc_interface/configuration.rb
@@ -19,6 +19,15 @@ module HmrcInterface
       @headers.merge!(headers)
     end
 
+    def scopes
+      @scopes&.join(",")
+    end
+
+    def scopes=(scopes)
+      raise ConfigurationError, "scopes must be provider as an array" unless scopes.is_a?(Array)
+      @scopes = scopes
+    end
+
     def logger
       @logger ||= defined?(Rails) ? Rails.logger : Logger.new($stdout)
     end

--- a/spec/lib/hmrc_interface/client_spec.rb
+++ b/spec/lib/hmrc_interface/client_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe HmrcInterface::Client do
         it "retrieves new access_token using client_credentials grant type" do
           expect(access_token).to eq(new_token)
           expect(oauth_client).to have_received(:client_credentials)
-          expect(client_credentials).to have_received(:get_token)
+          expect(client_credentials).to have_received(:get_token).with(scopes: "use_case_one,use_case_two")
         end
       end
 
@@ -95,7 +95,7 @@ RSpec.describe HmrcInterface::Client do
         it "retrieves new access_token using client_credentials grant type" do
           expect(access_token).to eq(new_token)
           expect(oauth_client).to have_received(:client_credentials)
-          expect(client_credentials).to have_received(:get_token)
+          expect(client_credentials).to have_received(:get_token).with(scopes: "use_case_one,use_case_two")
         end
       end
     end

--- a/spec/lib/hmrc_interface/request/result_spec.rb
+++ b/spec/lib/hmrc_interface/request/result_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe HmrcInterface::Request::Result do
           a_request(
             :post,
             "#{fake_host}/oauth/token"
-          ).with(body: "grant_type=client_credentials",
+          ).with(body: "grant_type=client_credentials&scopes=use_case_one%2Cuse_case_two",
                  headers: { 'Accept'=>'*/*',
                             'Content-Type'=>'application/x-www-form-urlencoded',
                             'Accept-Encoding'=>/.*/,

--- a/spec/lib/hmrc_interface/request/submission_spec.rb
+++ b/spec/lib/hmrc_interface/request/submission_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe HmrcInterface::Request::Submission do
           a_request(
             :post,
             "#{fake_host}/oauth/token"
-          ).with(body: "grant_type=client_credentials",
+          ).with(body: "grant_type=client_credentials&scopes=use_case_one%2Cuse_case_two",
                  headers: { 'Accept'=>'*/*',
                             'Content-Type'=>'application/x-www-form-urlencoded',
                             'Accept-Encoding'=>/.*/,


### PR DESCRIPTION
## What
Request scope specific doorkeeper tokens

[related PR for apply](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/5386)

Doorkeeper is used by HMRC interface to authenticate
requests. It is currently locked at doorkeeper 5.5.4 because
the handling of scopes changed in 5.6+.

However, we can request a token for specific scopes in
the current version 5.5.4 without breakages. ~~NEEDS TESTING~~ ✅ .

Once HMRC interface API is updated to use doorkeeper 5.6.6
(latest security patch), Assure app will continue to work
transparently.

Note: you can only request and successfully receive tokens
for scopes for which your application has been registered
with doorkeeper on HMRC Interface



## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
