### PR TITLE
AP-4171: Add soft deletion capability to bulk submission and submission models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'aws-sdk-s3', require: false
 gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem 'devise'
+gem "discard", "~> 1.2"
 gem 'dotenv-rails'
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    discard (1.2.1)
+      activerecord (>= 4.2, < 8)
     docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -510,6 +512,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  discard (~> 1.2)
   dotenv-rails
   erb_lint
   factory_bot_rails

--- a/app/models/bulk_submission.rb
+++ b/app/models/bulk_submission.rb
@@ -1,5 +1,6 @@
 class BulkSubmission < ApplicationRecord
   include StatusSettable
+  include Discard::Model
 
   belongs_to :user
   has_many :submissions, dependent: :destroy

--- a/app/models/bulk_submission.rb
+++ b/app/models/bulk_submission.rb
@@ -2,6 +2,14 @@ class BulkSubmission < ApplicationRecord
   include StatusSettable
   include Discard::Model
 
+  after_discard do
+    submissions.discard_all
+  end
+
+  after_undiscard do
+    submissions.undiscard_all
+  end
+
   belongs_to :user
   has_many :submissions, dependent: :destroy
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,5 +1,6 @@
 class Submission < ApplicationRecord
   include StatusSettable
+  include Discard::Model
 
   belongs_to :bulk_submission
 

--- a/db/migrate/20230618211606_add_discarded_at_to_bulk_submissions.rb
+++ b/db/migrate/20230618211606_add_discarded_at_to_bulk_submissions.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToBulkSubmissions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bulk_submissions, :discarded_at, :datetime
+    add_index :bulk_submissions, :discarded_at
+  end
+end

--- a/db/migrate/20230618211622_add_discarded_at_to_submissions.rb
+++ b/db/migrate/20230618211622_add_discarded_at_to_submissions.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToSubmissions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :submissions, :discarded_at, :datetime
+    add_index :submissions, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_27_141829) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_18_211622) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -50,6 +50,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_141829) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_bulk_submissions_on_discarded_at"
     t.index ["user_id"], name: "index_bulk_submissions_on_user_id"
   end
 
@@ -67,7 +69,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_141829) do
     t.jsonb "hmrc_interface_result", default: "{}", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
     t.index ["bulk_submission_id"], name: "index_submissions_on_bulk_submission_id"
+    t.index ["discarded_at"], name: "index_submissions_on_discarded_at"
     t.index ["hmrc_interface_id"], name: "index_submissions_on_hmrc_interface_id", unique: true
     t.index ["hmrc_interface_result"], name: "index_submissions_on_hmrc_interface_result", using: :gin
   end

--- a/spec/models/bulk_submission_spec.rb
+++ b/spec/models/bulk_submission_spec.rb
@@ -4,6 +4,19 @@ RSpec.describe BulkSubmission, type: :model do
   let(:instance) { create(:bulk_submission, user:) }
   let(:user) { create(:user) }
 
+  it_behaves_like "discardable model"
+
+  it "is status settable" do
+    expected_status_methods = ["!", "?"].each_with_object([]) do |c, memo|
+      memo << ["pending#{c}",
+               "preparing#{c}", "prepared#{c}", "processing#{c}",
+               "completed#{c}", "exhausted#{c}",
+               "writing#{c}", "ready#{c}"]
+    end
+
+    expect(instance).to respond_to(*expected_status_methods.flatten)
+  end
+
   describe "#user" do
     subject { instance.user }
 
@@ -79,16 +92,5 @@ RSpec.describe BulkSubmission, type: :model do
 
       it { is_expected.to be true }
     end
-  end
-
-  it "is status settable" do
-    expected_status_methods = ["!", "?"].each_with_object([]) do |c, memo|
-      memo << ["pending#{c}",
-               "preparing#{c}", "prepared#{c}", "processing#{c}",
-               "completed#{c}", "exhausted#{c}",
-               "writing#{c}", "ready#{c}"]
-    end
-
-    expect(instance).to respond_to(*expected_status_methods.flatten)
   end
 end

--- a/spec/models/bulk_submission_spec.rb
+++ b/spec/models/bulk_submission_spec.rb
@@ -6,6 +6,41 @@ RSpec.describe BulkSubmission, type: :model do
 
   it_behaves_like "discardable model"
 
+  describe "#dicard" do
+    subject(:discard) { instance.discard }
+
+    before do
+      submission
+    end
+
+    let(:submission) { create(:submission, bulk_submission: instance) }
+
+    it "discards associated submissions" do
+      expect { discard }
+        .to change { submission.reload.discarded? }
+          .from(false)
+          .to(true)
+    end
+  end
+
+  describe "#undicard" do
+    subject(:undiscard) { instance.undiscard }
+
+    before do
+      submission
+      instance.discard!
+    end
+
+    let(:submission) { create(:submission, bulk_submission: instance) }
+
+    it "undiscards associated submissions" do
+      expect { undiscard }
+        .to change { submission.reload.discarded? }
+          .from(true)
+          .to(false)
+    end
+  end
+
   it "is status settable" do
     expected_status_methods = ["!", "?"].each_with_object([]) do |c, memo|
       memo << ["pending#{c}",

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -3,6 +3,18 @@ require 'rails_helper'
 RSpec.describe Submission, type: :model do
   let(:instance) { create(:submission) }
 
+  it_behaves_like "discardable model"
+
+  it "is status settable" do
+    expected_status_methods = ["!", "?"].each_with_object([]) do |c, memo|
+      memo << ["pending#{c}", "submitting#{c}", "submitted#{c}",
+               "completing#{c}", "created#{c}", "processing#{c}",
+               "completed#{c}", "failed#{c}", "exhausted#{c}"]
+    end
+
+    expect(instance).to respond_to(*expected_status_methods.flatten)
+  end
+
   describe "#bulk_submission" do
     subject(:bulk_submission) { instance.bulk_submission }
 
@@ -79,15 +91,5 @@ RSpec.describe Submission, type: :model do
       expect(submission.errors[:period_start_at]).to include("Start date cannot be after end date")
       expect(submission.errors[:period_end_at]).to include("End date cannot be before Start date")
     end
-  end
-
-  it "is status settable" do
-    expected_status_methods = ["!", "?"].each_with_object([]) do |c, memo|
-      memo << ["pending#{c}", "submitting#{c}", "submitted#{c}",
-               "completing#{c}", "created#{c}", "processing#{c}",
-               "completed#{c}", "failed#{c}", "exhausted#{c}"]
-    end
-
-    expect(instance).to respond_to(*expected_status_methods.flatten)
   end
 end

--- a/spec/support/shared_examples/discardable_examples.rb
+++ b/spec/support/shared_examples/discardable_examples.rb
@@ -1,0 +1,8 @@
+RSpec.shared_examples "discardable model" do
+  it "is discardable" do
+    expect(instance).to respond_to(:discarded_at, :discard, :discard!, :discarded?,
+                                   :undiscard, :undiscard!, :undiscarded?, :kept?)
+
+    expect(instance.class).to respond_to(:discarded, :undiscarded, :kept, :with_discarded)
+  end
+end


### PR DESCRIPTION
## What
Add soft deletion capability to bulk submission and submission data

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4171)

 We should "hide" cancelled or removed bulk submissions from the list of
 "checked details" but retain record data for auditing purposes.
 
 I have used the [discard gem](https://rubygems.org/gems/discard/versions/1.2.1) because:
- it follows Apply's pattern
- is simple and robust implementation of a common pattern

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
