### PR TITLE
AP-4171: enable soft-delete for bulk submissions

### DIFF
--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -1,12 +1,11 @@
 class BulkSubmissionsController < ApplicationController
   def index
-    @bulk_submissions = BulkSubmission.all
+    @bulk_submissions = BulkSubmission.undiscarded.order(created_at: :desc)
   end
 
   def destroy
     bulk_submission = BulkSubmission.find(params[:id])
-    bulk_submission.original_file.purge
-    bulk_submission.destroy!
+    bulk_submission.discard!
     redirect_back(fallback_location: authenticated_root_path)
   end
 

--- a/app/views/bulk_submissions/index.html.erb
+++ b/app/views/bulk_submissions/index.html.erb
@@ -16,7 +16,7 @@
       end
 
       table.with_body do |body|
-        @bulk_submissions.order(created_at: :desc).each do |bulk_submission|
+        @bulk_submissions.each do |bulk_submission|
           filename = bulk_submission&.original_file&.filename
 
           body.with_row do |row|

--- a/app/workers/bulk_submissions_worker.rb
+++ b/app/workers/bulk_submissions_worker.rb
@@ -2,7 +2,7 @@ class BulkSubmissionsWorker < ApplicationWorker
   sidekiq_options queue: DefaultQueueNameService.call
 
   def perform
-    pending_bulk_submissions_ids = BulkSubmission.where(status: 'pending').ids
+    pending_bulk_submissions_ids = BulkSubmission.undiscarded.where(status: 'pending').ids
 
     pending_bulk_submissions_ids.each do |bulk_submission_id|
       BulkSubmissionWorker.perform_async(bulk_submission_id)

--- a/app/workers/purge_sensitive_data_worker.rb
+++ b/app/workers/purge_sensitive_data_worker.rb
@@ -5,8 +5,11 @@ class PurgeSensitiveDataWorker < ApplicationWorker
       bulk_submission.original_file.purge
       bulk_submission.result_file.purge
       bulk_submission.submissions.each do |submission|
-        submission.update!(first_name: 'purged', last_name: 'purged', dob: Date.parse('1970-01-01'), nino: 'AB123456C', 
-hmrc_interface_result: '{}')
+        submission.update!(first_name: 'purged',
+                           last_name: 'purged',
+                           dob: Date.parse('1970-01-01'),
+                           nino: 'AB123456C',
+                           hmrc_interface_result: '{}')
       end
     end
 
@@ -16,7 +19,8 @@ hmrc_interface_result: '{}')
 private
 
   def purgeable_bulk_submissions
-    BulkSubmission.where(expires_at: nil, 
-created_at: ..1.month.ago).or(BulkSubmission.where(expires_at: ..Time.current))
+    BulkSubmission
+      .where(expires_at: nil, created_at: ..1.month.ago)
+      .or(BulkSubmission.where(expires_at: ..Time.current))
   end
 end

--- a/spec/factories/bulk_submissions.rb
+++ b/spec/factories/bulk_submissions.rb
@@ -15,6 +15,14 @@ FactoryBot.define do
       status { 'ready' }
     end
 
+    trait :discarded do
+      discarded_at { Time.current - 1.second }
+    end
+
+    trait :undiscarded do
+      discarded_at { nil }
+    end
+
     # name must be of a file that exists in `spec/fixtures/files/`
     transient do
       original_file_fixture_name { nil }

--- a/spec/requests/bulk_submissions_controller_spec.rb
+++ b/spec/requests/bulk_submissions_controller_spec.rb
@@ -21,25 +21,99 @@ RSpec.describe BulkSubmissionsController, type: :request do
       expect(response.body).to include("Checked details")
       expect(response.body).to include("Check new details")
     end
+
+    context "with an undiscarded and a discarded bulk submission" do
+      before do
+        discarded
+        undiscarded
+      end
+
+      let(:discarded) do
+        create(:bulk_submission,
+               :discarded,
+               :pending,
+               :with_original_file,
+               original_file_fixture_name: "multiple_bulk_submission.csv",
+               original_file_fixture_content_type: "text/csv",
+               user_id: user.id)
+      end
+
+      let(:undiscarded) do
+        create(:bulk_submission,
+               :undiscarded,
+               :pending,
+               :with_original_file,
+               original_file_fixture_name: "basic_bulk_submission.csv",
+               original_file_fixture_content_type: "text/csv",
+               user_id: user.id)
+      end
+
+      it "displays only undiscarded bulk submissions" do
+        get bulk_submissions_path
+        expect(response.body).to include("basic_bulk_submission.csv")
+        expect(response.body).not_to include("multiple_bulk_submission.csv")
+      end
+    end
+
+    context "with multiple bulk submissions from multiple days" do
+      before do
+        older
+        newer
+      end
+
+      let(:newer) do
+        create(:bulk_submission,
+               :pending,
+               :with_original_file,
+               original_file_fixture_name: "multiple_bulk_submission.csv",
+               original_file_fixture_content_type: "text/csv",
+               user_id: user.id)
+      end
+
+      let(:older) do
+        travel_to(1.day.ago) do
+          create(:bulk_submission,
+                 :ready,
+                 :with_original_file,
+                 :with_result_file,
+                 original_file_fixture_name: "basic_bulk_submission.csv",
+                 original_file_fixture_content_type: "text/csv",
+                 user_id: user.id)
+        end
+      end
+
+      it "displays bulk submissions, newest first, by date created" do
+        get bulk_submissions_path
+        expect(response.body).to match(/multiple_bulk_submission.csv.+basic_bulk_submission.csv/)
+      end
+    end
   end
 
   describe "DELETE /destroy" do
     before { bulk_submission }
 
-    it "destroys the requested bulk_submission" do
+    it "does not destroy any bulk_submission" do
       expect {
         delete bulk_submission_path(bulk_submission.id)
-      }.to change(BulkSubmission, :count).by(-1)
+      }.to change(BulkSubmission, :count).by(0)
     end
 
-    it "destroys the requested bulk_submissions attachments" do
+    it "does not destroy any bulk_submissions attachments" do
       expect {
         delete bulk_submission_path(bulk_submission.id)
-      }.to change(ActiveStorage::Attachment, :count).by(-1)
+      }.to change(ActiveStorage::Attachment, :count).by(0)
+    end
+
+    it "discards the requested bulk_submission" do
+      expect {
+        delete bulk_submission_path(bulk_submission.id)
+      }.to change { bulk_submission.reload.discarded? }
+              .from(false)
+              .to(true)
     end
 
     it "redirects to bulk submissions index or authenticated root path" do
-      get process_all_bulk_submissions_path
+      delete bulk_submission_path(bulk_submission.id)
       expect(response)
         .to redirect_to(bulk_submissions_path)
         .or redirect_to(authenticated_root_path)
@@ -68,7 +142,9 @@ RSpec.describe BulkSubmissionsController, type: :request do
     it "redirects to fallback location and renders flash" do
       get process_all_bulk_submissions_path
       expect(flash[:notice]).to match(/processing all pending bulk submissions/i)
-      expect(response).to redirect_to(authenticated_root_path)
+      expect(response)
+        .to redirect_to(bulk_submissions_path)
+        .or redirect_to(authenticated_root_path)
     end
   end
 end

--- a/spec/workers/purge_sensitive_data_worker_spec.rb
+++ b/spec/workers/purge_sensitive_data_worker_spec.rb
@@ -1,5 +1,32 @@
 require "rails_helper"
 
+RSpec.shared_examples "purges sensitive data" do
+  it "purges the original file" do
+    perform
+    bulk_submission.reload
+    expect(bulk_submission.original_file.attachment).to be_nil
+    expect(bulk_submission.original_file.blob).to be_nil
+  end
+
+  it "purges the result file" do
+    perform
+    bulk_submission.reload
+    expect(bulk_submission.result_file.attachment).to be_nil
+    expect(bulk_submission.result_file.blob).to be_nil
+  end
+
+  it "updates the submission record" do
+    perform
+    expect(submission.reload).to have_attributes(
+      first_name: 'purged',
+      last_name: 'purged',
+      nino:'AB123456C',
+      dob: Date.parse('1970-01-01'),
+      hmrc_interface_result: '{}'
+    )
+  end
+end
+
 RSpec.describe PurgeSensitiveDataWorker, type: :worker do
   describe ".perform_async" do
     subject(:perform_async) { described_class.perform_async }
@@ -25,13 +52,22 @@ RSpec.describe PurgeSensitiveDataWorker, type: :worker do
     subject(:perform) { described_class.new.perform }
 
     let(:bulk_submission) { create(:bulk_submission, :with_original_file, :with_result_file, expires_at:) }
+
     let(:submission) do
- create(:submission, :with_completed_use_case_one_hmrc_interface_result, first_name: 'Rosie', last_name: 'Conway', 
-nino: 'JC654321A', dob: '1977-03-08'.to_date, bulk_submission:) end
+      create(:submission,
+              :with_completed_use_case_one_hmrc_interface_result,
+              first_name: 'Rosie',
+              last_name: 'Conway',
+              nino: 'JC654321A',
+              dob: '1977-03-08'.to_date,
+              bulk_submission:)
+    end
+
     let(:expires_at) { nil }
 
     around do |example|
       scheduled_time = Time.current.midnight + 20.hours
+
       travel_to(scheduled_time) do
         freeze_time
         bulk_submission
@@ -45,30 +81,7 @@ nino: 'JC654321A', dob: '1977-03-08'.to_date, bulk_submission:) end
     context "when the bulk submission expires now" do
       let(:expires_at) { Time.current }
 
-      it "purges the original file" do
-        perform
-        bulk_submission.reload
-        expect(bulk_submission.original_file.attachment).to be_nil
-        expect(bulk_submission.original_file.blob).to be_nil
-      end
-  
-      it "purges the result file" do
-        perform
-        bulk_submission.reload
-        expect(bulk_submission.result_file.attachment).to be_nil
-        expect(bulk_submission.result_file.blob).to be_nil
-      end
-
-      it "updates the submission record" do
-        perform
-        expect(submission.reload).to have_attributes(
-          first_name: 'purged',
-          last_name: 'purged',
-          nino:'AB123456C',
-          dob: Date.parse('1970-01-01'),
-          hmrc_interface_result: '{}'
-        )
-      end
+      include_examples "purges sensitive data"
     end
 
     context "when the bulk submission expires 1 second from now" do
@@ -102,34 +115,27 @@ nino: 'JC654321A', dob: '1977-03-08'.to_date, bulk_submission:) end
 
     context "when the bulk submission is not set to expire but was created one month ago" do
       let(:bulk_submission) do
-        create(:bulk_submission, :with_original_file, :with_result_file, expires_at: nil, 
-created_at: 1.month.ago)
+        create(:bulk_submission,
+               :with_original_file,
+               :with_result_file,
+               expires_at: nil,
+               created_at: 1.month.ago)
       end
-    
-      it "purges the original file" do
-        perform
-        bulk_submission.reload
-        expect(bulk_submission.original_file.attachment).to be_nil
-        expect(bulk_submission.original_file.blob).to be_nil
+
+      include_examples "purges sensitive data"
+    end
+
+    context "when the bulk submission is ready but discarded and expires now" do
+      let(:bulk_submission) do
+        create(:bulk_submission,
+               :discarded,
+               :ready,
+               :with_original_file,
+               :with_result_file,
+               expires_at: Time.current)
       end
-    
-      it "purges the result file" do
-        perform
-        bulk_submission.reload
-        expect(bulk_submission.result_file.attachment).to be_nil
-        expect(bulk_submission.result_file.blob).to be_nil
-      end
-    
-      it "updates the submission record" do
-        perform
-        expect(submission.reload).to have_attributes(
-          first_name: 'purged',
-          last_name: 'purged',
-          nino:'AB123456C',
-          dob: Date.parse('1970-01-01'),
-          hmrc_interface_result: '{}'
-        )
-      end
+
+      include_examples "purges sensitive data"
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4171)

Soft delete bulk submissions from index page, rather than destroy. This is
so we can retain the data for auditing purposes. Therefore both "Cancel", of pending,
and "Remove", of ready, bulk submissions should discard/soft-delete them. 

It follows, that if a bulk submission is discarded it should not be visible on the "Check details"
page and should not be processed, if it has not been already.

## TODO:
- [x] remove and cancel buttons should discard, not destroy, bulk_submissions
- [x] remove and cancel buttons should discard, not destroy, associated submissions
- [x] discarded items should not be visible on index
- [x] discarded items should not be processed
- [x] discarded items should be "purged" 1 month after creation

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
