### PR TITLE
ap-4165: add govuk button styling to cancel and remove buttons

### DIFF
--- a/app/views/bulk_submissions/index.html.erb
+++ b/app/views/bulk_submissions/index.html.erb
@@ -27,9 +27,9 @@
 
             row.with_cell do
               if bulk_submission.pending?
-                button_to(t(".cancel_html", filename:),
+                govuk_button_to(t(".cancel_html", filename:),
                           bulk_submission_path(bulk_submission.id),
-                          method: :delete)
+                          { method: :delete, secondary: true } )
               elsif bulk_submission.ready?
                 link_to(t(".download_html",filename:),
                         rails_blob_path(bulk_submission.result_file.blob,
@@ -38,10 +38,10 @@
             end
 
             row.with_cell do
-              if bulk_submission.ready?
-                button_to(t(".remove_html", filename:),
+              if bulk_submission.ready? || bulk_submission.exhausted?
+                govuk_button_to(t(".remove_html", filename:),
                           bulk_submission_path(bulk_submission.id),
-                          method: :delete)
+                          { method: :delete, secondary: true } )
               end
             end
           end

--- a/spec/factories/bulk_submissions.rb
+++ b/spec/factories/bulk_submissions.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
       discarded_at { nil }
     end
 
+    trait :exhausted do
+      status { 'exhausted' }
+    end
+
     # name must be of a file that exists in `spec/fixtures/files/`
     transient do
       original_file_fixture_name { nil }

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "sign in", type: :system do
 
           expect(page).to have_selector(".govuk-table__body tr")
           click_button("Remove", match: :one)
-          expect(page).to have_no_selector(".govuk-table__body tr")
+          expect(page).not_to have_selector(".govuk-table__body tr")
         end
       end
 
@@ -127,6 +127,31 @@ RSpec.describe "sign in", type: :system do
           expect(page).not_to have_selector(".govuk-table__cell", text: "Download")
           expect(page).not_to have_selector(".govuk-table__cell", text: "Remove")
           expect(page).not_to have_selector(".govuk-table__cell", text: "Cancel")
+        end
+      end
+    end
+
+    context "with an existing exhausted bulk_submission" do
+      before do
+        create(:bulk_submission, :with_original_file, :exhausted)
+      end
+
+      it "user can remove them" do
+        visit "/bulk_submissions"
+
+        within(".govuk-table") do
+          expect(page)
+            .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
+            .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--red", text: /Exhausted/i)
+            .and have_selector(".govuk-table__cell", text: "Remove")
+
+          expect(page).not_to have_selector(".govuk-table__cell", text: "Cancel")
+          expect(page).not_to have_selector(".govuk-table__cell", text: "Download")
+
+          expect(page).to have_selector(".govuk-table__body tr")
+          click_button("Remove", match: :one)
+          expect(page).not_to have_selector(".govuk-table__body tr")
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4165)

Added govuk styled buttons for Remove and Cancel

Added a Remove button for exhausted bulk_subissions

**TODO**

Add confirmations to the Remove and Cancel buttons (see https://dsdmoj.atlassian.net/browse/AP-4224).

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
