### PR TITLE
AP-4220: Add bulk submission show page with cancel and remove confirmation

### DIFF
--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -1,4 +1,9 @@
 class BulkSubmissionsController < ApplicationController
+  def show
+    @bulk_submission = BulkSubmission.find(params[:id])
+    @context = params[:context]
+  end
+
   def index
     @bulk_submissions = BulkSubmission.undiscarded.order(created_at: :desc)
   end
@@ -6,7 +11,9 @@ class BulkSubmissionsController < ApplicationController
   def destroy
     bulk_submission = BulkSubmission.find(params[:id])
     bulk_submission.discard!
-    redirect_back(fallback_location: authenticated_root_path)
+
+    flash[:notice] = "Deleted \"#{bulk_submission.original_file.filename}\""
+    redirect_to authenticated_root_path
   end
 
   # NOTE: route only available in test/development or uat

--- a/app/views/bulk_submissions/index.html.erb
+++ b/app/views/bulk_submissions/index.html.erb
@@ -22,26 +22,28 @@
           body.with_row do |row|
             row.with_cell(text: bulk_submission.created_at&.to_fs(:date_only))
             row.with_cell(text: bulk_submission.expires_at&.to_fs(:date_only))
-            row.with_cell(text: filename)
+            row.with_cell(text: govuk_link_to(filename,
+                                              bulk_submission_path(bulk_submission.id, context: :view),
+                                              method: :get,
+                                              text_colour: true))
             row.with_cell(text: govuk_status_tag(bulk_submission.status))
 
             row.with_cell do
               if bulk_submission.pending?
-                govuk_button_to(t(".cancel_html", filename:),
-                          bulk_submission_path(bulk_submission.id),
-                          { method: :delete, secondary: true } )
+                govuk_link_to(t(".cancel_html", filename:),
+                              bulk_submission_path(bulk_submission.id, context: :cancel),
+                              method: :get)
               elsif bulk_submission.ready?
-                link_to(t(".download_html",filename:),
-                        rails_blob_path(bulk_submission.result_file.blob,
-                          disposition: 'attachment'))
+                govuk_link_to(t(".download_html",filename:),
+                              rails_blob_path(bulk_submission.result_file.blob, disposition: 'attachment'))
               end
             end
 
             row.with_cell do
-              if bulk_submission.ready? || bulk_submission.exhausted?
-                govuk_button_to(t(".remove_html", filename:),
-                          bulk_submission_path(bulk_submission.id),
-                          { method: :delete, secondary: true } )
+              if bulk_submission.ready?
+                govuk_link_to(t(".remove_html", filename:),
+                                bulk_submission_path(bulk_submission.id, context: :remove),
+                                method: :get)
               end
             end
           end

--- a/app/views/bulk_submissions/index.html.erb
+++ b/app/views/bulk_submissions/index.html.erb
@@ -40,7 +40,7 @@
             end
 
             row.with_cell do
-              if bulk_submission.ready?
+              if bulk_submission.ready? || bulk_submission.exhausted?
                 govuk_link_to(t(".remove_html", filename:),
                                 bulk_submission_path(bulk_submission.id, context: :remove),
                                 method: :get)

--- a/app/views/bulk_submissions/show.html.erb
+++ b/app/views/bulk_submissions/show.html.erb
@@ -1,0 +1,38 @@
+<%= govuk_back_link(href: "/") %>
+
+<% filename = @bulk_submission&.original_file&.filename %> <%# erblint:disable Rubocop %>
+
+<%= form_with(
+      model: @bulk_submission,
+      method: :delete,
+      local: true
+    ) do |form| %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl"><%= t(".page_heading") %></h1>
+
+      <%= govuk_summary_list(
+        rows: [
+          { key: { text: t(".uploaded_by") }, value: { text: @bulk_submission.user.full_name } },
+          { key: { text: t(".created_at") }, value: { text: @bulk_submission.created_at&.to_fs(:date_only) } },
+          { key: { text: t(".expires_at") }, value: { text: @bulk_submission.expires_at&.to_fs(:date_only) } },
+          { key: { text: t(".filename") }, value: { text: filename } },
+          { key: { text: t(".status") }, value: { text: govuk_status_tag(@bulk_submission.status) } }
+        ]
+      ) %>
+
+      <% if @context == "cancel" %>
+        <%= form.govuk_submit(t(".confirm_cancel_html", filename:), warning: true) %>
+      <% elsif @context == "remove" %>
+        <%= form.govuk_submit(t(".confirm_remove_html", filename:), warning: true) %>
+      <% end %>
+
+      <% if @bulk_submission.ready? %>
+        <%= govuk_button_link_to(t(".download_html", filename:),
+                                 rails_blob_path(@bulk_submission.result_file.blob, disposition: 'attachment'),
+                                 secondary: true) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en/views/bulk_submissions.yml
+++ b/config/locales/en/views/bulk_submissions.yml
@@ -13,3 +13,13 @@ en:
       process_all: Process all pending
       remove_html: Remove <span class='govuk-visually-hidden'>%{filename}</span>
       status: Status
+    show:
+      confirm_cancel_html: Confirm cancel <span class='govuk-visually-hidden'>%{filename}</span>
+      confirm_remove_html: Confirm remove <span class='govuk-visually-hidden'>%{filename}</span>
+      created_at: Date requested
+      download_html: Download <span class='govuk-visually-hidden'>%{filename}</span>
+      expires_at: Expiry date
+      filename: File name
+      page_heading: Checked detail
+      status: Status
+      uploaded_by: Uploaded by

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: :show
-  resources :bulk_submissions, only: [:index, :destroy] do
+  resources :bulk_submissions, only: [:show, :index, :destroy] do
     if Rails.env.development? || Rails.env.test? || Rails.host.uat?
       get :process_all, on: :collection
     end

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -46,6 +46,27 @@ RSpec.describe "sign in", type: :system do
         create(:bulk_submission, :with_original_file, :pending)
       end
 
+      it "user can view them" do
+        visit "/bulk_submissions"
+
+        within(".govuk-table") do
+          expect(page)
+            .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
+            .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--yellow", text: /Pending/i)
+            .and have_selector(".govuk-table__cell", text: "Cancel")
+
+          expect(page).to have_selector(".govuk-table__body tr")
+          click_link("basic_bulk_submission.csv", match: :first)
+        end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).not_to have_button("Confirm cancel")
+
+        click_link("Back")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+      end
+
       it "user can cancel them" do
         visit "/bulk_submissions"
 
@@ -74,6 +95,27 @@ RSpec.describe "sign in", type: :system do
     context "with an existing ready bulk_submission" do
       before do
         create(:bulk_submission, :with_original_file, :with_result_file, :ready)
+      end
+
+      it "user can view them" do
+        visit "/bulk_submissions"
+
+        within(".govuk-table") do
+          expect(page)
+            .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
+            .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--green", text: /Ready/i)
+            .and have_selector(".govuk-table__cell", text: "Remove")
+
+          expect(page).to have_selector(".govuk-table__body tr")
+          click_link("basic_bulk_submission.csv", match: :first)
+        end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).not_to have_button("Confirm remove")
+
+        click_link("Back")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
       end
 
       it "user can remove them" do
@@ -166,9 +208,17 @@ RSpec.describe "sign in", type: :system do
           expect(page).not_to have_selector(".govuk-table__cell", text: "Download")
 
           expect(page).to have_selector(".govuk-table__body tr")
-          click_button("Remove", match: :one)
-          expect(page).not_to have_selector(".govuk-table__body tr")
+          click_link("Remove", match: :one)
         end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_button("Confirm remove")
+        click_button("Confirm remove")
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+        expect(page).to have_selector(".govuk-notification-banner__content",
+                                      text: "Deleted \"basic_bulk_submission.csv\"")
+        expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end
   end

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -57,9 +57,17 @@ RSpec.describe "sign in", type: :system do
             .and have_selector(".govuk-table__cell", text: "Cancel")
 
           expect(page).to have_selector(".govuk-table__body tr")
-          click_button("Cancel", match: :one)
-          expect(page).not_to have_selector(".govuk-table__body tr")
+          click_link("Cancel", match: :one)
         end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_button("Confirm cancel")
+        click_button("Confirm cancel")
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+        expect(page).to have_selector(".govuk-notification-banner__content",
+                                      text: "Deleted \"basic_bulk_submission.csv\"")
+        expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end
 
@@ -82,9 +90,17 @@ RSpec.describe "sign in", type: :system do
           expect(page).not_to have_selector(".govuk-table__cell", text: "Cancel")
 
           expect(page).to have_selector(".govuk-table__body tr")
-          click_button("Remove", match: :one)
-          expect(page).not_to have_selector(".govuk-table__body tr")
+          click_link("Remove", match: :one)
         end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_button("Confirm remove")
+        click_button("Confirm remove")
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+        expect(page).to have_selector(".govuk-notification-banner__content",
+                                      text: "Deleted \"basic_bulk_submission.csv\"")
+        expect(page).not_to have_selector(".govuk-table__body tr")
       end
 
       it "user can download them", js: true do


### PR DESCRIPTION
## What
Add a bulk submission show page and use for view cancel and remove

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4220)

This allows cancel and remove to be links, not buttons, and
to take users to the show page with a confirmation for deletion.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
