### PR TITLE
AP-4129/4224: Add a confirmation mechanism for cancel and remove

### DIFF
--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -14,9 +14,9 @@ class BulkSubmissionsController < ApplicationController
 
     flash[:notice] = case bulk_submission_params[:context]
     when "remove"
-      "Removed \"#{bulk_submission.original_file.filename}\""
+      I18n.t("bulk_submissions.flash.removed", filename: bulk_submission.original_file.filename)
     when "cancel"
-      "Cancelled \"#{bulk_submission.original_file.filename}\""
+      I18n.t('bulk_submissions.flash.cancelled', filename: bulk_submission.original_file.filename)
     end
 
     redirect_to authenticated_root_path
@@ -26,7 +26,7 @@ class BulkSubmissionsController < ApplicationController
   def process_all
     BulkSubmissionsWorker.perform_async
 
-    flash[:notice] = "processing all pending bulk submissions..."
+    flash[:notice] = I18n.t("bulk_submissions.flash.process_all")
     redirect_back(fallback_location: authenticated_root_path)
   end
 

--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -1,7 +1,7 @@
 class BulkSubmissionsController < ApplicationController
   def show
-    @bulk_submission = BulkSubmission.find(params[:id])
-    @context = params[:context]
+    @bulk_submission = BulkSubmission.find(bulk_submission_params[:id])
+    @context = bulk_submission_params[:context]
   end
 
   def index
@@ -9,10 +9,16 @@ class BulkSubmissionsController < ApplicationController
   end
 
   def destroy
-    bulk_submission = BulkSubmission.find(params[:id])
+    bulk_submission = BulkSubmission.find(bulk_submission_params[:id])
     bulk_submission.discard!
 
-    flash[:notice] = "Deleted \"#{bulk_submission.original_file.filename}\""
+    flash[:notice] = case bulk_submission_params[:context]
+    when "remove"
+      "Removed \"#{bulk_submission.original_file.filename}\""
+    when "cancel"
+      "Cancelled \"#{bulk_submission.original_file.filename}\""
+    end
+
     redirect_to authenticated_root_path
   end
 
@@ -22,5 +28,9 @@ class BulkSubmissionsController < ApplicationController
 
     flash[:notice] = "processing all pending bulk submissions..."
     redirect_back(fallback_location: authenticated_root_path)
+  end
+
+  def bulk_submission_params
+    params.permit(:id, :context)
   end
 end

--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -1,4 +1,9 @@
 class BulkSubmissionsController < ApplicationController
+  def show
+    @bulk_submission = BulkSubmission.find(params[:id])
+    @context = params[:context]
+  end
+
   def index
     @bulk_submissions = BulkSubmission.undiscarded.order(created_at: :desc)
   end
@@ -6,7 +11,9 @@ class BulkSubmissionsController < ApplicationController
   def destroy
     bulk_submission = BulkSubmission.find(params[:id])
     bulk_submission.discard!
-    redirect_back(fallback_location: authenticated_root_path)
+
+    flash[:notice] = "Deleted \"#{bulk_submission.original_file.filename}\""
+    redirect_to authenticated_root_path
   end
 
   # NOTE: route only available in test/development or uat

--- a/app/views/bulk_submissions/index.html.erb
+++ b/app/views/bulk_submissions/index.html.erb
@@ -22,26 +22,28 @@
           body.with_row do |row|
             row.with_cell(text: bulk_submission.created_at&.to_fs(:date_only))
             row.with_cell(text: bulk_submission.expires_at&.to_fs(:date_only))
-            row.with_cell(text: filename)
+            row.with_cell(text: govuk_link_to(filename,
+                                              bulk_submission_path(bulk_submission.id, context: :view),
+                                              method: :get,
+                                              text_colour: true))
             row.with_cell(text: govuk_status_tag(bulk_submission.status))
 
             row.with_cell do
               if bulk_submission.pending?
-                govuk_button_to(t(".cancel_html", filename:),
-                          bulk_submission_path(bulk_submission.id),
-                          { method: :delete, secondary: true } )
+                govuk_link_to(t(".cancel_html", filename:),
+                              bulk_submission_path(bulk_submission.id, context: :cancel),
+                              method: :get)
               elsif bulk_submission.ready?
-                link_to(t(".download_html",filename:),
-                        rails_blob_path(bulk_submission.result_file.blob,
-                          disposition: 'attachment'))
+                govuk_link_to(t(".download_html",filename:),
+                              rails_blob_path(bulk_submission.result_file.blob, disposition: 'attachment'))
               end
             end
 
             row.with_cell do
-              if bulk_submission.ready? || bulk_submission.exhausted?
-                govuk_button_to(t(".remove_html", filename:),
-                          bulk_submission_path(bulk_submission.id),
-                          { method: :delete, secondary: true } )
+              if bulk_submission.ready?
+                govuk_link_to(t(".remove_html", filename:),
+                                bulk_submission_path(bulk_submission.id, context: :remove),
+                                method: :get)
               end
             end
           end

--- a/app/views/bulk_submissions/index.html.erb
+++ b/app/views/bulk_submissions/index.html.erb
@@ -40,7 +40,7 @@
             end
 
             row.with_cell do
-              if bulk_submission.ready?
+              if bulk_submission.ready? || bulk_submission.exhausted?
                 govuk_link_to(t(".remove_html", filename:),
                                 bulk_submission_path(bulk_submission.id, context: :remove),
                                 method: :get)

--- a/app/views/bulk_submissions/show.html.erb
+++ b/app/views/bulk_submissions/show.html.erb
@@ -10,7 +10,13 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl"><%= t(".page_heading") %></h1>
+      <% if @context == "cancel" %>
+        <h1 class="govuk-heading-xl"><%= t(".page_heading.cancel") %></h1>
+      <% elsif @context == "remove" %>
+        <h1 class="govuk-heading-xl"><%= t(".page_heading.remove") %></h1>
+      <% else %>
+        <h1 class="govuk-heading-xl"><%= t(".page_heading.view") %></h1>
+      <% end %>
 
       <%= govuk_summary_list(
         rows: [

--- a/app/views/bulk_submissions/show.html.erb
+++ b/app/views/bulk_submissions/show.html.erb
@@ -1,0 +1,38 @@
+<%= govuk_back_link(href: "/") %>
+
+<% filename = @bulk_submission&.original_file&.filename %> <%# erblint:disable Rubocop %>
+
+<%= form_with(
+      model: @bulk_submission,
+      method: :delete,
+      local: true
+    ) do |form| %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl"><%= t(".page_heading") %></h1>
+
+      <%= govuk_summary_list(
+        rows: [
+          { key: { text: t(".uploaded_by") }, value: { text: @bulk_submission.user.full_name } },
+          { key: { text: t(".created_at") }, value: { text: @bulk_submission.created_at&.to_fs(:date_only) } },
+          { key: { text: t(".expires_at") }, value: { text: @bulk_submission.expires_at&.to_fs(:date_only) } },
+          { key: { text: t(".filename") }, value: { text: filename } },
+          { key: { text: t(".status") }, value: { text: govuk_status_tag(@bulk_submission.status) } }
+        ]
+      ) %>
+
+      <% if @context == "cancel" %>
+        <%= form.govuk_submit(t(".confirm_cancel_html", filename:), warning: true) %>
+      <% elsif @context == "remove" %>
+        <%= form.govuk_submit(t(".confirm_remove_html", filename:), warning: true) %>
+      <% end %>
+
+      <% if @bulk_submission.ready? %>
+        <%= govuk_button_link_to(t(".download_html", filename:),
+                                 rails_blob_path(@bulk_submission.result_file.blob, disposition: 'attachment'),
+                                 secondary: true) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/bulk_submissions/show.html.erb
+++ b/app/views/bulk_submissions/show.html.erb
@@ -22,6 +22,8 @@
         ]
       ) %>
 
+      <%= hidden_field_tag(:context, @context) %>
+
       <% if @context == "cancel" %>
         <%= form.govuk_submit(t(".confirm_cancel_html", filename:), warning: true) %>
       <% elsif @context == "remove" %>

--- a/app/views/bulk_submissions/show.html.erb
+++ b/app/views/bulk_submissions/show.html.erb
@@ -24,10 +24,12 @@
 
       <%= hidden_field_tag(:context, @context) %>
 
-      <% if @context == "cancel" %>
-        <%= form.govuk_submit(t(".confirm_cancel_html", filename:), warning: true) %>
-      <% elsif @context == "remove" %>
-        <%= form.govuk_submit(t(".confirm_remove_html", filename:), warning: true) %>
+      <% unless @bulk_submission.processing? %>
+        <% if @context == "cancel" %>
+          <%= form.govuk_submit(t(".confirm_cancel_html", filename:), warning: true) %>
+        <% elsif @context == "remove" %>
+          <%= form.govuk_submit(t(".confirm_remove_html", filename:), warning: true) %>
+        <% end %>
       <% end %>
 
       <% if @bulk_submission.ready? %>

--- a/config/locales/en/views/bulk_submissions.yml
+++ b/config/locales/en/views/bulk_submissions.yml
@@ -24,6 +24,6 @@ en:
       download_html: Download <span class='govuk-visually-hidden'>%{filename}</span>
       expires_at: Expiry date
       filename: File name
-      page_heading: Checked detail
+      page_heading: About this file
       status: Status
       uploaded_by: Uploaded by

--- a/config/locales/en/views/bulk_submissions.yml
+++ b/config/locales/en/views/bulk_submissions.yml
@@ -1,6 +1,10 @@
 ---
 en:
   bulk_submissions:
+    flash:
+      cancelled: Cancelled "%{filename}"
+      process_all: Processing all pending bulk submissions...
+      removed: Removed "%{filename}"
     index:
       action: Action
       cancel_html: Cancel <span class='govuk-visually-hidden'>%{filename}</span>

--- a/config/locales/en/views/bulk_submissions.yml
+++ b/config/locales/en/views/bulk_submissions.yml
@@ -13,3 +13,13 @@ en:
       process_all: Process all pending
       remove_html: Remove <span class='govuk-visually-hidden'>%{filename}</span>
       status: Status
+    show:
+      confirm_cancel_html: Confirm cancel <span class='govuk-visually-hidden'>%{filename}</span>
+      confirm_remove_html: Confirm remove <span class='govuk-visually-hidden'>%{filename}</span>
+      created_at: Date requested
+      download_html: Download <span class='govuk-visually-hidden'>%{filename}</span>
+      expires_at: Expiry date
+      filename: File name
+      page_heading: Checked detail
+      status: Status
+      uploaded_by: Uploaded by

--- a/config/locales/en/views/bulk_submissions.yml
+++ b/config/locales/en/views/bulk_submissions.yml
@@ -2,14 +2,14 @@
 en:
   bulk_submissions:
     flash:
-      cancelled: Cancelled "%{filename}"
+      cancelled: You've cancelled the check on %{filename}
       process_all: Processing all pending bulk submissions...
-      removed: Removed "%{filename}"
+      removed: You've removed %{filename}
     index:
       action: Action
       cancel_html: Cancel <span class='govuk-visually-hidden'>%{filename}</span>
       created_at: Date requested
-      download_html: Download <span class='govuk-visually-hidden'>%{filename}</span>
+      download_html: Download results <span class='govuk-visually-hidden'>for %{filename}</span>
       expires_at: Expiry date
       filename: File name
       new_submission: Check new details
@@ -18,12 +18,15 @@ en:
       remove_html: Remove <span class='govuk-visually-hidden'>%{filename}</span>
       status: Status
     show:
-      confirm_cancel_html: Confirm cancel <span class='govuk-visually-hidden'>%{filename}</span>
-      confirm_remove_html: Confirm remove <span class='govuk-visually-hidden'>%{filename}</span>
+      confirm_cancel_html: Yes, cancel the check <span class='govuk-visually-hidden'>on %{filename}</span>
+      confirm_remove_html: Yes, remove <span class='govuk-visually-hidden'>%{filename}</span>
       created_at: Date requested
       download_html: Download <span class='govuk-visually-hidden'>%{filename}</span>
       expires_at: Expiry date
       filename: File name
-      page_heading: About this file
+      page_heading:
+        cancel: Are you sure you want to cancel this check?
+        remove: Are you sure you want to remove this file?
+        view: About this file
       status: Status
       uploaded_by: Uploaded by

--- a/config/locales/en/views/bulk_submissions.yml
+++ b/config/locales/en/views/bulk_submissions.yml
@@ -9,7 +9,7 @@ en:
       action: Action
       cancel_html: Cancel <span class='govuk-visually-hidden'>%{filename}</span>
       created_at: Date requested
-      download_html: Download results <span class='govuk-visually-hidden'>for %{filename}</span>
+      download_html: Download results <span class='govuk-visually-hidden'>file for %{filename}</span>
       expires_at: Expiry date
       filename: File name
       new_submission: Check new details
@@ -21,7 +21,7 @@ en:
       confirm_cancel_html: Yes, cancel the check <span class='govuk-visually-hidden'>on %{filename}</span>
       confirm_remove_html: Yes, remove <span class='govuk-visually-hidden'>%{filename}</span>
       created_at: Date requested
-      download_html: Download <span class='govuk-visually-hidden'>%{filename}</span>
+      download_html: Download results <span class='govuk-visually-hidden'>file for %{filename}</span>
       expires_at: Expiry date
       filename: File name
       page_heading:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: :show
-  resources :bulk_submissions, only: [:index, :destroy] do
+  resources :bulk_submissions, only: [:show, :index, :destroy] do
     if Rails.env.development? || Rails.env.test? || Rails.host.uat?
       get :process_all, on: :collection
     end

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "View bulk submission index page", type: :system do
           click_link("basic_bulk_submission.csv", match: :first)
         end
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).not_to have_button("Confirm cancel")
 
         click_link("Back")
@@ -81,7 +81,7 @@ RSpec.describe "View bulk submission index page", type: :system do
           click_link("Cancel", match: :one)
         end
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).to have_button("Confirm cancel")
       end
     end
@@ -106,7 +106,7 @@ RSpec.describe "View bulk submission index page", type: :system do
           click_link("basic_bulk_submission.csv", match: :first)
         end
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).not_to have_button("Confirm remove")
 
         click_link("Back")
@@ -131,7 +131,7 @@ RSpec.describe "View bulk submission index page", type: :system do
           click_link("Remove", match: :one)
         end
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).to have_button("Confirm remove")
       end
 
@@ -204,7 +204,7 @@ RSpec.describe "View bulk submission index page", type: :system do
           click_link("Remove", match: :one)
         end
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).to have_button("Confirm remove")
       end
     end

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -46,6 +46,27 @@ RSpec.describe "sign in", type: :system do
         create(:bulk_submission, :with_original_file, :pending)
       end
 
+      it "user can view them" do
+        visit "/bulk_submissions"
+
+        within(".govuk-table") do
+          expect(page)
+            .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
+            .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--yellow", text: /Pending/i)
+            .and have_selector(".govuk-table__cell", text: "Cancel")
+
+          expect(page).to have_selector(".govuk-table__body tr")
+          click_link("basic_bulk_submission.csv", match: :first)
+        end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).not_to have_button("Confirm cancel")
+
+        click_link("Back")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+      end
+
       it "user can cancel them" do
         visit "/bulk_submissions"
 
@@ -74,6 +95,27 @@ RSpec.describe "sign in", type: :system do
     context "with an existing ready bulk_submission" do
       before do
         create(:bulk_submission, :with_original_file, :with_result_file, :ready)
+      end
+
+      it "user can view them" do
+        visit "/bulk_submissions"
+
+        within(".govuk-table") do
+          expect(page)
+            .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
+            .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--green", text: /Ready/i)
+            .and have_selector(".govuk-table__cell", text: "Remove")
+
+          expect(page).to have_selector(".govuk-table__body tr")
+          click_link("basic_bulk_submission.csv", match: :first)
+        end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).not_to have_button("Confirm remove")
+
+        click_link("Back")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
       end
 
       it "user can remove them" do
@@ -166,9 +208,17 @@ RSpec.describe "sign in", type: :system do
           expect(page).not_to have_selector(".govuk-table__cell", text: "Download")
 
           expect(page).to have_selector(".govuk-table__body tr")
-          click_button("Remove", match: :one)
-          expect(page).not_to have_selector(".govuk-table__body tr")
+          click_link("Remove", match: :one)
         end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_button("Confirm remove")
+        click_button("Confirm remove")
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+        expect(page).to have_selector(".govuk-notification-banner__content",
+                                      text: "Deleted \"basic_bulk_submission.csv\"")
+        expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end
   end

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "View bulk submission index page", type: :system do
         end
 
         expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
-        expect(page).not_to have_button("Confirm cancel")
+        expect(page).not_to have_button("cancel")
 
         click_link("Back")
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
@@ -81,8 +81,8 @@ RSpec.describe "View bulk submission index page", type: :system do
           click_link("Cancel", match: :one)
         end
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
-        expect(page).to have_button("Confirm cancel")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Are you sure you want to cancel this check?")
+        expect(page).to have_button("Yes, cancel the check on basic_bulk_submission.csv")
       end
     end
 
@@ -107,7 +107,7 @@ RSpec.describe "View bulk submission index page", type: :system do
         end
 
         expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
-        expect(page).not_to have_button("Confirm remove")
+        expect(page).not_to have_button("basic_bulk_submission")
 
         click_link("Back")
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
@@ -131,8 +131,8 @@ RSpec.describe "View bulk submission index page", type: :system do
           click_link("Remove", match: :one)
         end
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
-        expect(page).to have_button("Confirm remove")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Are you sure you want to remove this file?")
+        expect(page).to have_button("Yes, remove basic_bulk_submission.csv")
       end
 
       it "user can download them", js: true do
@@ -204,8 +204,8 @@ RSpec.describe "View bulk submission index page", type: :system do
           click_link("Remove", match: :one)
         end
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
-        expect(page).to have_button("Confirm remove")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Are you sure you want to remove this file?")
+        expect(page).to have_button("Yes, remove basic_bulk_submission.csv")
       end
     end
   end

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe "sign in", type: :system do
+RSpec.describe "View bulk submission index page", type: :system do
   context "with unauthorised user" do
     it "redirects user back to landing page" do
       visit "/bulk_submissions"
@@ -67,7 +67,7 @@ RSpec.describe "sign in", type: :system do
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
       end
 
-      it "user can cancel them" do
+      it "user can go to the cancel confirmation page" do
         visit "/bulk_submissions"
 
         within(".govuk-table") do
@@ -83,12 +83,6 @@ RSpec.describe "sign in", type: :system do
 
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
         expect(page).to have_button("Confirm cancel")
-        click_button("Confirm cancel")
-
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
-        expect(page).to have_selector(".govuk-notification-banner__content",
-                                      text: "Cancelled \"basic_bulk_submission.csv\"")
-        expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end
 
@@ -104,6 +98,7 @@ RSpec.describe "sign in", type: :system do
           expect(page)
             .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
             .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_link("basic_bulk_submission.csv")
             .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--green", text: /Ready/i)
             .and have_selector(".govuk-table__cell", text: "Remove")
 
@@ -118,13 +113,14 @@ RSpec.describe "sign in", type: :system do
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
       end
 
-      it "user can remove them" do
+      it "user can go to the remove confirmation page" do
         visit "/bulk_submissions"
 
         within(".govuk-table") do
           expect(page)
             .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
             .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_link("basic_bulk_submission.csv")
             .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--green", text: /Ready/i)
             .and have_selector(".govuk-table__cell", text: "Download")
             .and have_selector(".govuk-table__cell", text: "Remove")
@@ -137,12 +133,6 @@ RSpec.describe "sign in", type: :system do
 
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
         expect(page).to have_button("Confirm remove")
-        click_button("Confirm remove")
-
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
-        expect(page).to have_selector(".govuk-notification-banner__content",
-                                      text: "Removed \"basic_bulk_submission.csv\"")
-        expect(page).not_to have_selector(".govuk-table__body tr")
       end
 
       it "user can download them", js: true do
@@ -152,6 +142,7 @@ RSpec.describe "sign in", type: :system do
             expect(page)
             .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
             .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_link("basic_bulk_submission.csv")
             .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--green", text: /Ready/i)
             .and have_selector(".govuk-table__cell", text: "Download")
             .and have_selector(".govuk-table__cell", text: "Remove")
@@ -180,6 +171,7 @@ RSpec.describe "sign in", type: :system do
           expect(page)
             .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
             .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_link("basic_bulk_submission.csv")
             .and have_selector(".govuk-table__cell", text: /Processing/i)
 
           expect(page).not_to have_selector(".govuk-table__cell", text: "Download")
@@ -194,13 +186,14 @@ RSpec.describe "sign in", type: :system do
         create(:bulk_submission, :with_original_file, :exhausted)
       end
 
-      it "user can remove them" do
+      it "user can go to the remove confirmation page" do
         visit "/bulk_submissions"
 
         within(".govuk-table") do
           expect(page)
             .to have_selector(".govuk-table__cell", text: Date.current.strftime("%d %b %Y"))
             .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
+            .and have_link("basic_bulk_submission.csv")
             .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--red", text: /Exhausted/i)
             .and have_selector(".govuk-table__cell", text: "Remove")
 
@@ -213,12 +206,6 @@ RSpec.describe "sign in", type: :system do
 
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
         expect(page).to have_button("Confirm remove")
-        click_button("Confirm remove")
-
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
-        expect(page).to have_selector(".govuk-notification-banner__content",
-                                      text: "Removed \"basic_bulk_submission.csv\"")
-        expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end
   end

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "View bulk submission index page", type: :system do
             .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
             .and have_link("basic_bulk_submission.csv")
             .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--green", text: /Ready/i)
-            .and have_selector(".govuk-table__cell", text: "Download")
+            .and have_selector(".govuk-table__cell", text: "Download results file for basic_bulk_submission.csv")
             .and have_selector(".govuk-table__cell", text: "Remove")
 
           expect(page).not_to have_selector(".govuk-table__cell", text: "Cancel")
@@ -144,13 +144,13 @@ RSpec.describe "View bulk submission index page", type: :system do
             .and have_selector(".govuk-table__cell", text: "basic_bulk_submission.csv")
             .and have_link("basic_bulk_submission.csv")
             .and have_selector(".govuk-table__cell .govuk-tag.govuk-tag--green", text: /Ready/i)
-            .and have_selector(".govuk-table__cell", text: "Download")
+            .and have_selector(".govuk-table__cell", text: "Download results file for basic_bulk_submission.csv")
             .and have_selector(".govuk-table__cell", text: "Remove")
 
           expect(page).not_to have_selector(".govuk-table__cell", text: "Cancel")
 
           expect(page).to have_selector(".govuk-table__body tr")
-          click_link("Download", match: :one)
+          click_link("Download results file for basic_bulk_submission.csv", match: :one)
 
           wait_for_download
           expect(downloads.length).to eq(1)

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -57,9 +57,17 @@ RSpec.describe "sign in", type: :system do
             .and have_selector(".govuk-table__cell", text: "Cancel")
 
           expect(page).to have_selector(".govuk-table__body tr")
-          click_button("Cancel", match: :one)
-          expect(page).not_to have_selector(".govuk-table__body tr")
+          click_link("Cancel", match: :one)
         end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_button("Confirm cancel")
+        click_button("Confirm cancel")
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+        expect(page).to have_selector(".govuk-notification-banner__content",
+                                      text: "Deleted \"basic_bulk_submission.csv\"")
+        expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end
 
@@ -82,9 +90,17 @@ RSpec.describe "sign in", type: :system do
           expect(page).not_to have_selector(".govuk-table__cell", text: "Cancel")
 
           expect(page).to have_selector(".govuk-table__body tr")
-          click_button("Remove", match: :one)
-          expect(page).not_to have_selector(".govuk-table__body tr")
+          click_link("Remove", match: :one)
         end
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_button("Confirm remove")
+        click_button("Confirm remove")
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+        expect(page).to have_selector(".govuk-notification-banner__content",
+                                      text: "Deleted \"basic_bulk_submission.csv\"")
+        expect(page).not_to have_selector(".govuk-table__body tr")
       end
 
       it "user can download them", js: true do

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "sign in", type: :system do
 
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
         expect(page).to have_selector(".govuk-notification-banner__content",
-                                      text: "Deleted \"basic_bulk_submission.csv\"")
+                                      text: "Cancelled \"basic_bulk_submission.csv\"")
         expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end
@@ -141,7 +141,7 @@ RSpec.describe "sign in", type: :system do
 
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
         expect(page).to have_selector(".govuk-notification-banner__content",
-                                      text: "Deleted \"basic_bulk_submission.csv\"")
+                                      text: "Removed \"basic_bulk_submission.csv\"")
         expect(page).not_to have_selector(".govuk-table__body tr")
       end
 
@@ -217,7 +217,7 @@ RSpec.describe "sign in", type: :system do
 
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
         expect(page).to have_selector(".govuk-notification-banner__content",
-                                      text: "Deleted \"basic_bulk_submission.csv\"")
+                                      text: "Removed \"basic_bulk_submission.csv\"")
         expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end

--- a/spec/system/bulk_submission_show_spec.rb
+++ b/spec/system/bulk_submission_show_spec.rb
@@ -1,0 +1,186 @@
+require "system_helper"
+
+RSpec.describe "View bulk submission show page", type: :system do
+  context "with unauthorised user" do
+    before { bulk_submission }
+
+    let(:bulk_submission) { create(:bulk_submission, :with_original_file, :pending) }
+
+    it "redirects user back to landing page" do
+      visit "/bulk_submissions/#{bulk_submission.id}"
+      expect(page).to have_content("Start now")
+    end
+  end
+
+  context "with an authorised user" do
+    before do
+      bulk_submission
+      sign_in user
+    end
+
+    let(:user) { create(:user, :with_matching_stubbed_oauth_details) }
+
+    context "with an existing pending bulk submission" do
+      let(:bulk_submission) { create(:bulk_submission, :with_original_file, :pending) }
+
+      it "user can view it" do
+        visit "/bulk_submissions/#{bulk_submission.id}"
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_link("Back")
+
+        within(".govuk-summary-list") do
+          expect(page)
+            .to have_selector(".govuk-summary-list__value", text: bulk_submission.user.full_name)
+            .and have_selector(".govuk-summary-list__value", text: bulk_submission.created_at.strftime("%d %b %Y"))
+            .and have_selector(".govuk-summary-list__value", text: "basic_bulk_submission.csv")
+            .and have_selector(".govuk-summary-list__value .govuk-tag.govuk-tag--yellow", text: /Pending/i)
+        end
+
+        expect(page).not_to have_button("Confirm")
+        expect(page).not_to have_link("Download")
+      end
+
+      it "user can cancel it" do
+        visit "/bulk_submissions"
+
+        click_link("Cancel", match: :one)
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+
+        expect(page).to have_button("Confirm cancel basic_bulk_submission.csv")
+        expect(page).not_to have_link("Download")
+
+        click_button("Confirm cancel")
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+        expect(page).to have_selector(".govuk-notification-banner__content",
+                                      text: "Cancelled \"basic_bulk_submission.csv\"")
+        expect(page).not_to have_selector(".govuk-table__body tr")
+      end
+    end
+
+    context "with an existing ready bulk submission" do
+      let(:bulk_submission) do
+        create(:bulk_submission,
+               :with_original_file,
+               :with_result_file,
+               :ready,
+               expires_at: Time.current.midnight + 1.day)
+      end
+
+      it "user can view it" do
+        visit "/bulk_submissions/#{bulk_submission.id}"
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_link("Back")
+
+        within(".govuk-summary-list") do
+          expect(page)
+            .to have_selector(".govuk-summary-list__value", text: bulk_submission.user.full_name)
+            .and have_selector(".govuk-summary-list__value", text: bulk_submission.created_at.strftime("%d %b %Y"))
+            .and have_selector(".govuk-summary-list__value", text: bulk_submission.expires_at.strftime("%d %b %Y"))
+            .and have_selector(".govuk-summary-list__value", text: "basic_bulk_submission.csv")
+            .and have_selector(".govuk-summary-list__value .govuk-tag.govuk-tag--green", text: /Ready/i)
+        end
+
+        expect(page).not_to have_button("Confirm")
+        expect(page).to have_link("Download basic_bulk_submission.csv")
+      end
+
+      it "user can remove it" do
+        visit "/bulk_submissions"
+
+        click_link("Remove", match: :one)
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+
+        expect(page).to have_button("Confirm remove basic_bulk_submission.csv")
+        expect(page).to have_link("Download")
+
+        click_button("Confirm remove")
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+        expect(page).to have_selector(".govuk-notification-banner__content",
+                                      text: "Removed \"basic_bulk_submission.csv\"")
+        expect(page).not_to have_selector(".govuk-table__body tr")
+      end
+
+      it "user can download it", js: true do
+        visit "/bulk_submissions/#{bulk_submission.id}"
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_link("Download basic_bulk_submission.csv")
+
+        click_link("Download", match: :one)
+        wait_for_download
+
+        expect(downloads.length).to eq(1)
+        expect(download).to match(/basic_bulk_submission-result.csv/)
+      end
+    end
+
+    context "with an existing processing bulk_submission" do
+      let(:bulk_submission) { create(:bulk_submission, :with_original_file, :processing) }
+
+      it "user can view it" do
+        visit "/bulk_submissions/#{bulk_submission.id}"
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+
+        within(".govuk-summary-list") do
+          expect(page)
+            .to have_selector(".govuk-summary-list__value", text: bulk_submission.user.full_name)
+            .and have_selector(".govuk-summary-list__value", text: bulk_submission.created_at.strftime("%d %b %Y"))
+            .and have_selector(".govuk-summary-list__value", text: "basic_bulk_submission.csv")
+            .and have_selector(".govuk-summary-list__value .govuk-tag.govuk-tag--blue", text: /Processing/i)
+        end
+
+        expect(page).not_to have_button("Confirm")
+        expect(page).not_to have_link("Download")
+      end
+
+      it "user can NOT remove it" do
+        visit "/bulk_submissions/#{bulk_submission.id}?context=remove"
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).not_to have_button("Confirm")
+        expect(page).not_to have_link("Download")
+      end
+    end
+
+    context "with an existing exhausted bulk_submission" do
+      let(:bulk_submission) { create(:bulk_submission, :with_original_file, :exhausted) }
+
+      it "user can view it" do
+        visit "/bulk_submissions/#{bulk_submission.id}"
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+
+        within(".govuk-summary-list") do
+          expect(page)
+            .to have_selector(".govuk-summary-list__value", text: bulk_submission.user.full_name)
+            .and have_selector(".govuk-summary-list__value", text: bulk_submission.created_at.strftime("%d %b %Y"))
+            .and have_selector(".govuk-summary-list__value", text: "basic_bulk_submission.csv")
+            .and have_selector(".govuk-summary-list__value .govuk-tag.govuk-tag--red", text: /Exhausted/i)
+        end
+
+        expect(page).not_to have_button("Confirm")
+        expect(page).not_to have_link("Download")
+      end
+
+      it "user can remove it" do
+        visit "/bulk_submissions/#{bulk_submission.id}?context=remove"
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_button("Confirm")
+        expect(page).not_to have_link("Download")
+
+       click_button("Confirm remove")
+
+        expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
+        expect(page).to have_selector(".govuk-notification-banner__content",
+                                      text: "Removed \"basic_bulk_submission.csv\"")
+        expect(page).not_to have_selector(".govuk-table__body tr")
+      end
+    end
+  end
+end

--- a/spec/system/bulk_submission_show_spec.rb
+++ b/spec/system/bulk_submission_show_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "View bulk submission show page", type: :system do
       it "user can view it" do
         visit "/bulk_submissions/#{bulk_submission.id}"
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).to have_link("Back")
 
         within(".govuk-summary-list") do
@@ -45,7 +45,7 @@ RSpec.describe "View bulk submission show page", type: :system do
         visit "/bulk_submissions"
 
         click_link("Cancel", match: :one)
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
 
         expect(page).to have_button("Confirm cancel basic_bulk_submission.csv")
         expect(page).not_to have_link("Download")
@@ -71,7 +71,7 @@ RSpec.describe "View bulk submission show page", type: :system do
       it "user can view it" do
         visit "/bulk_submissions/#{bulk_submission.id}"
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).to have_link("Back")
 
         within(".govuk-summary-list") do
@@ -91,7 +91,7 @@ RSpec.describe "View bulk submission show page", type: :system do
         visit "/bulk_submissions"
 
         click_link("Remove", match: :one)
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
 
         expect(page).to have_button("Confirm remove basic_bulk_submission.csv")
         expect(page).to have_link("Download")
@@ -107,7 +107,7 @@ RSpec.describe "View bulk submission show page", type: :system do
       it "user can download it", js: true do
         visit "/bulk_submissions/#{bulk_submission.id}"
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).to have_link("Download basic_bulk_submission.csv")
 
         click_link("Download", match: :one)
@@ -124,7 +124,7 @@ RSpec.describe "View bulk submission show page", type: :system do
       it "user can view it" do
         visit "/bulk_submissions/#{bulk_submission.id}"
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
 
         within(".govuk-summary-list") do
           expect(page)
@@ -141,7 +141,7 @@ RSpec.describe "View bulk submission show page", type: :system do
       it "user can NOT remove it" do
         visit "/bulk_submissions/#{bulk_submission.id}?context=remove"
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).not_to have_button("Confirm")
         expect(page).not_to have_link("Download")
       end
@@ -153,7 +153,7 @@ RSpec.describe "View bulk submission show page", type: :system do
       it "user can view it" do
         visit "/bulk_submissions/#{bulk_submission.id}"
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
 
         within(".govuk-summary-list") do
           expect(page)
@@ -170,7 +170,7 @@ RSpec.describe "View bulk submission show page", type: :system do
       it "user can remove it" do
         visit "/bulk_submissions/#{bulk_submission.id}?context=remove"
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "Checked detail")
+        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
         expect(page).to have_button("Confirm")
         expect(page).not_to have_link("Download")
 

--- a/spec/system/bulk_submission_show_spec.rb
+++ b/spec/system/bulk_submission_show_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "View bulk submission show page", type: :system do
         end
 
         expect(page).not_to have_button("Confirm")
-        expect(page).to have_link("Download basic_bulk_submission.csv")
+        expect(page).to have_link("Download results file for basic_bulk_submission.csv")
       end
 
       it "user can remove it" do
@@ -94,7 +94,7 @@ RSpec.describe "View bulk submission show page", type: :system do
         expect(page).to have_selector(".govuk-heading-xl", text: "Are you sure you want to remove this file?")
 
         expect(page).to have_button("Yes, remove basic_bulk_submission.csv")
-        expect(page).to have_link("Download")
+        expect(page).to have_link("Download results file for basic_bulk_submission.csv")
 
         click_button("Yes, remove basic_bulk_submission.csv")
 
@@ -108,9 +108,9 @@ RSpec.describe "View bulk submission show page", type: :system do
         visit "/bulk_submissions/#{bulk_submission.id}"
 
         expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
-        expect(page).to have_link("Download basic_bulk_submission.csv")
+        expect(page).to have_link("Download results file for basic_bulk_submission.csv")
 
-        click_link("Download", match: :one)
+        click_link("Download results file for basic_bulk_submission.csv", match: :one)
         wait_for_download
 
         expect(downloads.length).to eq(1)

--- a/spec/system/bulk_submission_show_spec.rb
+++ b/spec/system/bulk_submission_show_spec.rb
@@ -45,16 +45,16 @@ RSpec.describe "View bulk submission show page", type: :system do
         visit "/bulk_submissions"
 
         click_link("Cancel", match: :one)
-        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Are you sure you want to cancel this check?")
 
-        expect(page).to have_button("Confirm cancel basic_bulk_submission.csv")
+        expect(page).to have_button("Yes, cancel the check on basic_bulk_submission.csv")
         expect(page).not_to have_link("Download")
 
-        click_button("Confirm cancel")
+        click_button("Yes, cancel the check on basic_bulk_submission.csv")
 
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
         expect(page).to have_selector(".govuk-notification-banner__content",
-                                      text: "Cancelled \"basic_bulk_submission.csv\"")
+                                      text: "You've cancelled the check on basic_bulk_submission.csv")
         expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end
@@ -91,16 +91,16 @@ RSpec.describe "View bulk submission show page", type: :system do
         visit "/bulk_submissions"
 
         click_link("Remove", match: :one)
-        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Are you sure you want to remove this file?")
 
-        expect(page).to have_button("Confirm remove basic_bulk_submission.csv")
+        expect(page).to have_button("Yes, remove basic_bulk_submission.csv")
         expect(page).to have_link("Download")
 
-        click_button("Confirm remove")
+        click_button("Yes, remove basic_bulk_submission.csv")
 
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
         expect(page).to have_selector(".govuk-notification-banner__content",
-                                      text: "Removed \"basic_bulk_submission.csv\"")
+                                      text: "You've removed basic_bulk_submission.csv")
         expect(page).not_to have_selector(".govuk-table__body tr")
       end
 
@@ -141,7 +141,7 @@ RSpec.describe "View bulk submission show page", type: :system do
       it "user can NOT remove it" do
         visit "/bulk_submissions/#{bulk_submission.id}?context=remove"
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Are you sure you want to remove this file?")
         expect(page).not_to have_button("Confirm")
         expect(page).not_to have_link("Download")
       end
@@ -170,15 +170,15 @@ RSpec.describe "View bulk submission show page", type: :system do
       it "user can remove it" do
         visit "/bulk_submissions/#{bulk_submission.id}?context=remove"
 
-        expect(page).to have_selector(".govuk-heading-xl", text: "About this file")
-        expect(page).to have_button("Confirm")
+        expect(page).to have_selector(".govuk-heading-xl", text: "Are you sure you want to remove this file?")
+        expect(page).to have_button("Yes, remove basic_bulk_submission.csv")
         expect(page).not_to have_link("Download")
 
-       click_button("Confirm remove")
+       click_button("Yes, remove basic_bulk_submission.csv")
 
         expect(page).to have_selector(".govuk-heading-xl", text: "Checked details")
         expect(page).to have_selector(".govuk-notification-banner__content",
-                                      text: "Removed \"basic_bulk_submission.csv\"")
+                                      text: "You've removed basic_bulk_submission.csv")
         expect(page).not_to have_selector(".govuk-table__body tr")
       end
     end


### PR DESCRIPTION
## What
Add a bulk submission show page and use for view cancel and remove

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4219)
[Link to story](https://dsdmoj.atlassian.net/browse/AP-4224)

This allows cancel and remove to be links, not buttons, and
to take users to the show page with a confirmation for deletion.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
