### PR TITLE
Add content security policy

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
   </head>
 
   <body class="govuk-template__body">
-    <script>
+    <script nonce="<%= request.content_security_policy_nonce %>">
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,13 +13,13 @@ Rails.application.configure do
     policy.script_src  :self, :https
     policy.style_src   :self, :https
     # Specify URI for violation reports
-    policy.report_uri "/csp-violation-report-endpoint"
+    # policy.report_uri "/csp-violation-report-endpoint"
   end
-#
-#  # Generate session nonces for permitted importmap and inline scripts
-#  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#  config.content_security_policy_nonce_directives = %w(script-src)
-#
-# # Report violations without enforcing the policy.
+
+  # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src]
+
+  # Report violations without enforcing the policy.
   config.content_security_policy_report_only = true
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,22 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https
+    # Specify URI for violation reports
+    policy.report_uri "/csp-violation-report-endpoint"
+  end
 #
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
+#  # Generate session nonces for permitted importmap and inline scripts
+#  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+#  config.content_security_policy_nonce_directives = %w(script-src)
 #
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+# # Report violations without enforcing the policy.
+  config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
## What
Add Content security policy

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Security hardening. Issue raised by Zap security report.

- Initialize default rail content security policy in report only mode
- Add nonce to the single inline script in application.html.erb

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
