### PR TITLE
Make session cookie store secure

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,2 @@
+# set secure: true
+Rails.application.config.session_store :cookie_store, key: "_laa_assure_hmrc_data_session", secure: Rails.env.production?


### PR DESCRIPTION
## What

Set secure flag on the applications session cookie so that the cookie cannot be accessed via unencrypted connections.

### Before:

![Screenshot 2023-06-26 at 08 34 53](https://github.com/ministryofjustice/laa-assure-hmrc-data/assets/8057224/018023e1-7732-4278-be53-36b47c778af8)

### After:

![Screenshot 2023-06-26 at 08 38 00](https://github.com/ministryofjustice/laa-assure-hmrc-data/assets/8057224/1e3da561-5d78-4af9-aabb-92470343ad32)


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
