### PR TITLE
Enable content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,5 +21,5 @@ Rails.application.configure do
   config.content_security_policy_nonce_directives = %w[script-src]
 
   # Report violations without enforcing the policy.
-  config.content_security_policy_report_only = true
+  # config.content_security_policy_report_only = true
 end


### PR DESCRIPTION
## What
Enable content security policy

Improve site security using CSP headers.Testing reveals
no negative impact from the policy directives.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
