### PR TITLE
Remove use of LOCAL_CLAMAV

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,9 +12,6 @@ OMNIAUTH_AZURE_REDIRECT_URI=
 # create "laa-assure-hmrc-data [your-name]" in Azure AD
 OMNIAUTH_AZURE_CLIENT_SECRET='TestAzureClientSecret'
 
-# Use clamav to scan for viruses
-LOCAL_CLAMAV=true
-
 # ---------------------------------------------------------------
 # Mock login credentials
 # localhost (and UAT) defined env vars for bypassing azure AD

--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -5,9 +5,6 @@ class MalwareScanner
     new(**args).call
   end
 
-  LOCAL_COMMAND = %w[clamdscan --fdpass --no-summary].freeze
-  CONTAINER_COMMAND = %w[clamdscan -c config/clamd.container.conf --stream --no-summary].freeze
-
   def initialize(file_path:, uploader:, file_details: nil, save_result: true)
     @file_path = file_path
     @uploader = uploader
@@ -53,6 +50,6 @@ private
   end
 
   def command
-    Rails.configuration.x.local_clamav == "true" ? LOCAL_COMMAND : CONTAINER_COMMAND
+    %w[clamdscan -c config/clamd.container.conf --stream --no-summary].freeze
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,7 +58,5 @@ module LaaAssureHmrcData
     config.x.mock_azure_password = ENV.fetch("MOCK_AZURE_PASSWORD", nil)
 
     config.x.host_env = ENV.fetch("HOST_ENV", nil)
-
-    config.x.local_clamav = ENV.fetch("LOCAL_CLAMAV", nil)
   end
 end


### PR DESCRIPTION
## What
Remove use of LOCAL_CLAMAV

The bin/install_clamav_on_mac was altered to configure clamav
to use TCP meaning local clamav should work in the same way
as production clamav client - it will work using the
`clamd.container.conf` setting.

Therefore we do not need the LOCAL_CLAMAV config option and command
that it causes the app to use - `--fdpass` (for improved speed?!).

```
--fdpass
Pass the file descriptor permissions to clamd. This is useful if clamd is
running as a different user as it is faster than streaming the file to clamd.
Only available if connected to clamd via local(unix) socket.
```

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
