### PR TITLE
Enable rubocop new cops by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  NewCops: enable
+
 require:
   - rubocop-performance
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,10 @@ Style/NumericLiterals:
 Lint/AmbiguousBlockAssociation:
   AllowedMethods: [change]
 
+Lint/RedundantDirGlobSort:
+  Exclude:
+    - spec/system_helper.rb
+
 Rails/SaveBang:
   Exclude:
     - spec/forms/bulk_submission_form_spec.rb

--- a/app/controllers/bulk_submission_forms_controller.rb
+++ b/app/controllers/bulk_submission_forms_controller.rb
@@ -3,6 +3,10 @@ class BulkSubmissionFormsController < ApplicationController
     @form = BulkSubmissionForm.new
   end
 
+  def edit
+    @form = BulkSubmissionForm.new(bulk_submission: bulk_submission_from_params)
+  end
+
   def create
     @form = BulkSubmissionForm.new(bulk_submission_form_params.merge(user_id: current_user.id, status: "pending"))
 
@@ -10,10 +14,6 @@ class BulkSubmissionFormsController < ApplicationController
       format.html { respond_to_create_with_html }
       format.json { respond_to_create_with_json }
     end
-  end
-
-  def edit
-    @form = BulkSubmissionForm.new(bulk_submission: bulk_submission_from_params)
   end
 
   def update

--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -1,11 +1,11 @@
 class BulkSubmissionsController < ApplicationController
+  def index
+    @bulk_submissions = BulkSubmission.undiscarded.order(created_at: :desc)
+  end
+
   def show
     @bulk_submission = BulkSubmission.find(bulk_submission_params[:id])
     @context = bulk_submission_params[:context]
-  end
-
-  def index
-    @bulk_submissions = BulkSubmission.undiscarded.order(created_at: :desc)
   end
 
   def destroy

--- a/app/workers/bulk_submission_status_worker.rb
+++ b/app/workers/bulk_submission_status_worker.rb
@@ -7,7 +7,7 @@ class BulkSubmissionStatusWorker < ApplicationWorker
     bulk_submission.exhausted!
 
     Sentry.capture_message <<~ERROR
-      "Failed #{job['class']} for bulk_submission #{job['args']}: #{job['error_message']} - status marked as \"exhausted\""
+      "Failed #{job['class']} for bulk_submission #{job['args']}: #{job['error_message']} - status marked as "exhausted""
     ERROR
   end
 

--- a/app/workers/hmrc_interface_result_worker.rb
+++ b/app/workers/hmrc_interface_result_worker.rb
@@ -4,7 +4,7 @@ class HmrcInterfaceResultWorker < HmrcInterfaceBaseWorker
     submission.exhausted!
 
     Sentry.capture_message <<~ERROR
-      "Failed #{job['class']} for submission #{job['args']}: #{job['error_message']} - status marked as \"exhausted\""
+      "Failed #{job['class']} for submission #{job['args']}: #{job['error_message']} - status marked as "exhausted""
     ERROR
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -282,14 +282,14 @@ Devise.setup do |config|
                   scope: [:openid, :email, :profile],
                   response_type: :code,
                   client_options: {
-                    identifier: ENV["OMNIAUTH_AZURE_CLIENT_ID"],
-                    secret: ENV["OMNIAUTH_AZURE_CLIENT_SECRET"],
-                    redirect_uri: ENV["OMNIAUTH_AZURE_REDIRECT_URI"],
+                    identifier: ENV.fetch("OMNIAUTH_AZURE_CLIENT_ID", nil),
+                    secret: ENV.fetch("OMNIAUTH_AZURE_CLIENT_SECRET", nil),
+                    redirect_uri: ENV.fetch("OMNIAUTH_AZURE_REDIRECT_URI", nil),
                   },
                   discovery: true,
-                  issuer: "https://login.microsoftonline.com/#{ENV["OMNIAUTH_AZURE_TENANT_ID"]}/v2.0",
+                  issuer: "https://login.microsoftonline.com/#{ENV.fetch("OMNIAUTH_AZURE_TENANT_ID", nil)}/v2.0",
                   pkce: true,
-                  extra_authorise_params: { tenant: ENV["OMNIAUTH_AZURE_TENANT_ID"] },
+                  extra_authorise_params: { tenant: ENV.fetch("OMNIAUTH_AZURE_TENANT_ID", nil) },
                   name: 'azure_ad'
 
   # ==> Warden configuration

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,7 +2,9 @@
 
 # Add to patch a zietwerk loading error due to not using ActionMailer with devise
 if Rails.autoloaders.zeitwerk_enabled?
+  # rubocop: disable Lint/EmptyClass
   class Devise::Mailer; end
+  # rubocop: enable Lint/EmptyClass
 end
 
 # Assuming you have not yet modified this file, each configuration option below

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,5 +59,5 @@ Rails.application.routes.draw do
 end
 
 def secure_compare(passed, stored)
-  Rack::Utils.secure_compare(::Digest::SHA256.hexdigest(passed), ::Digest::SHA256.hexdigest(stored))
+  Rack::Utils.secure_compare(Digest::SHA256.hexdigest(passed), Digest::SHA256.hexdigest(stored))
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     # - See https://thisdata.com/blog/timing-attacks-against-string-comparison/
     # - Use & (do not use &&) so that it doesn't short circuit.
     # - Use digests to stop length information leaking
-    secure_compare(username, ENV['SIDEKIQ_WEB_UI_USERNAME']) & secure_compare(password, ENV['SIDEKIQ_WEB_UI_PASSWORD'])
+    secure_compare(username, ENV.fetch('SIDEKIQ_WEB_UI_USERNAME', nil)) & secure_compare(password, ENV.fetch('SIDEKIQ_WEB_UI_PASSWORD', nil))
   end
 
   devise_for :users,

--- a/db/migrate/20230607074210_create_malware_scan_results.rb
+++ b/db/migrate/20230607074210_create_malware_scan_results.rb
@@ -1,5 +1,6 @@
 class CreateMalwareScanResults < ActiveRecord::Migration[7.0]
   def change
+    # rubocop:disable Rails/ThreeStateBooleanColumn
     create_table :malware_scan_results, id: :uuid do |t|
       t.references :uploader, type: :uuid, polymorphic: true
       t.boolean :virus_found, null: false
@@ -8,5 +9,6 @@ class CreateMalwareScanResults < ActiveRecord::Migration[7.0]
       t.boolean :scanner_working
       t.timestamps
     end
+    # rubocop:enable Rails/ThreeStateBooleanColumn
   end
 end

--- a/spec/factories/bulk_submissions.rb
+++ b/spec/factories/bulk_submissions.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     end
 
     trait :discarded do
-      discarded_at { Time.current - 1.second }
+      discarded_at { 1.second.ago }
     end
 
     trait :undiscarded do

--- a/spec/factories/bulk_submissions.rb
+++ b/spec/factories/bulk_submissions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :bulk_submission do
-    association :user
+    user
     status { 'pending' }
 
     trait :pending do

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :submission do
-    association :bulk_submission
+    bulk_submission
 
     period_start_at { 4.months.ago }
     period_end_at { 1.month.ago }

--- a/spec/forms/bulk_submission_form_spec.rb
+++ b/spec/forms/bulk_submission_form_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe BulkSubmissionForm, type: :model do
       end
 
       it "does not persist the bulk_submission" do
-        expect { save }.to change(BulkSubmission, :count).by(0)
+        expect { save }.not_to change(BulkSubmission, :count)
       end
 
       it "record upload attempt in database" do

--- a/spec/lib/hmrc_interface/client_spec.rb
+++ b/spec/lib/hmrc_interface/client_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe HmrcInterface::Client do
   describe "#access_token" do
     subject(:access_token) { client.access_token }
 
-    it { is_expected.to be_an ::OAuth2::AccessToken }
+    it { is_expected.to be_an OAuth2::AccessToken }
     it { is_expected.to respond_to :token }
     it { is_expected.to respond_to :expired? }
     it { expect(access_token.token).to eql "test-bearer-token" }
@@ -64,9 +64,9 @@ RSpec.describe HmrcInterface::Client do
     end
 
     context "when retrieving a new token" do
-      let(:oauth_client) { instance_double(::OAuth2::Client, client_credentials:) }
-      let(:client_credentials) { instance_double(::OAuth2::Strategy::ClientCredentials, get_token: new_token) }
-      let(:new_token) { instance_double(::OAuth2::AccessToken, token: 'new-fake-token') }
+      let(:oauth_client) { instance_double(OAuth2::Client, client_credentials:) }
+      let(:client_credentials) { instance_double(OAuth2::Strategy::ClientCredentials, get_token: new_token) }
+      let(:new_token) { instance_double(OAuth2::AccessToken, token: 'new-fake-token') }
 
       before do
         client.instance_variable_set(:@oauth_client, oauth_client)
@@ -86,7 +86,7 @@ RSpec.describe HmrcInterface::Client do
       end
 
       context "when token expired?" do
-        let(:old_token) { instance_double(::OAuth2::AccessToken, token: 'old-fake-token', expired?: true) }
+        let(:old_token) { instance_double(OAuth2::AccessToken, token: 'old-fake-token', expired?: true) }
 
         before do
           client.instance_variable_set(:@access_token, old_token)

--- a/spec/lib/hmrc_interface/configuration_spec.rb
+++ b/spec/lib/hmrc_interface/configuration_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe HmrcInterface::Configuration do
         allow(rails).to receive(:logger).and_return(rails_logger)
       end
 
-      let(:rails) { class_double("Rails") }
+      let(:rails) { class_double(Rails) }
       let(:rails_logger) { Class.new }
 
       it "defaults to using Rails.logger" do

--- a/spec/models/bulk_submission_spec.rb
+++ b/spec/models/bulk_submission_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BulkSubmission, type: :model do
+RSpec.describe BulkSubmission do
   let(:instance) { create(:bulk_submission, user:) }
   let(:user) { create(:user) }
 

--- a/spec/models/bulk_submission_spec.rb
+++ b/spec/models/bulk_submission_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe BulkSubmission do
   describe "#original_file" do
     subject { instance.original_file }
 
-    let(:file_io) { File.open(Rails.root.join('spec/fixtures/files/basic_bulk_submission.csv')) }
+    let(:file_io) { Rails.root.join('spec/fixtures/files/basic_bulk_submission.csv').open }
 
     it { is_expected.to be_an_instance_of(ActiveStorage::Attached::One) }
 

--- a/spec/models/concerns/hmrc_interface_resultable_spec.rb
+++ b/spec/models/concerns/hmrc_interface_resultable_spec.rb
@@ -375,14 +375,14 @@ RSpec.describe HmrcInterfaceResultable do
           "data" => [
             { "use_case" => "use_case_one" },
             {
-              "employments/paye/employments": [
+              "employments/paye/employments" => [
                 {
-                  "endDate": "2099-12-31",
-                  "startDate": "2023-01-26"
+                  "endDate" => "2099-12-31",
+                  "startDate" => "2023-01-26"
                 },
                 {
-                  "endDate": "2022-11-11",
-                  "startDate": "2022-09-11"
+                  "endDate" => "2022-11-11",
+                  "startDate" => "2022-09-11"
                 }
               ]
             },
@@ -401,14 +401,14 @@ RSpec.describe HmrcInterfaceResultable do
           "data" => [
             { "use_case" => "use_case_one" },
             {
-              "employments/paye/employments": [
+              "employments/paye/employments" => [
                 {
-                  "endDate": "2099-12-31",
-                  "startDate": "2023-01-26"
+                  "endDate" => "2099-12-31",
+                  "startDate" => "2023-01-26"
                 },
                 {
-                  "startDate": "2022-09-11",
-                  "endDate": "2022-11-11"
+                  "startDate" => "2022-09-11",
+                  "endDate" => "2022-11-11"
                 }
               ]
             },
@@ -427,10 +427,10 @@ RSpec.describe HmrcInterfaceResultable do
           "data" => [
             { "use_case" => "use_case_one" },
             {
-              "employments/paye/employments": [
+              "employments/paye/employments" => [
                 {
-                  "endDate": "2099-12-31",
-                  "startDate": "2023-01-26"
+                  "endDate" => "2099-12-31",
+                  "startDate" => "2023-01-26"
                 },
               ]
             },
@@ -781,14 +781,14 @@ RSpec.describe HmrcInterfaceResultable do
                 "income" => [
                   {
                     "taxablePay" => 222.22,
-                    "grossEarningsForNics": {
-                      "inPayPeriod1": 111.11
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 111.11
                     },
                   },
                   {
                     "taxablePay" => 444.44,
-                    "grossEarningsForNics": {
-                      "inPayPeriod1": 222.22
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 222.22
                     },
                   },
                 ]
@@ -883,15 +883,15 @@ RSpec.describe HmrcInterfaceResultable do
                   {
                     "paymentDate" => "2022-03-17",
                     "taxablePay" => 111.11,
-                    "grossEarningsForNics": {
-                      "inPayPeriod1": 50.00
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 50.00
                     },
                   },
                   {
                     "paymentDate" => "2022-02-20",
                     "taxablePay" => 222.22,
-                    "grossEarningsForNics": {
-                      "inPayPeriod1": 100.00
+                    "grossEarningsForNics" => {
+                      "inPayPeriod1" => 100.00
                     },
                   }
                 ]

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Submission, type: :model do
+RSpec.describe Submission do
   let(:instance) { create(:submission) }
 
   it_behaves_like "discardable model"

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Submission do
   describe "#bulk_submission" do
     subject(:bulk_submission) { instance.bulk_submission }
 
-    it { is_expected.to be_kind_of(BulkSubmission) }
+    it { is_expected.to be_a(BulkSubmission) }
   end
 
   context "when validating" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe User, type: :model do
+RSpec.describe User do
   describe "#email" do
     let(:email) { "Jo.Example@example.com" }
     let(:auth_provider) { "azure_ad" }

--- a/spec/requests/bulk_submission_forms_controller_spec.rb
+++ b/spec/requests/bulk_submission_forms_controller_spec.rb
@@ -3,7 +3,7 @@ require 'system_helper'
 # Request specs do not excercise JS, only the
 # non-JS controller actions
 #
-RSpec.describe BulkSubmissionFormsController, type: :request do
+RSpec.describe BulkSubmissionFormsController do
   before { sign_in user }
 
   let(:user) { create(:user) }

--- a/spec/requests/bulk_submission_forms_controller_spec.rb
+++ b/spec/requests/bulk_submission_forms_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe BulkSubmissionFormsController, type: :request do
       it "does not create bulk_submission" do
         expect {
           post bulk_submission_forms_path, params: bulk_submission_form_params
-        }.to change(BulkSubmission, :count).by(0)
+        }.not_to change(BulkSubmission, :count)
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe BulkSubmissionFormsController, type: :request do
       it "does not create bulk_submission" do
         expect {
           post bulk_submission_forms_path, params: bulk_submission_form_params
-        }.to change(BulkSubmission, :count).by(0)
+        }.not_to change(BulkSubmission, :count)
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe BulkSubmissionFormsController, type: :request do
       it "does not create bulk_submission" do
         expect {
           post bulk_submission_forms_path, params: bulk_submission_form_params
-        }.to change(BulkSubmission, :count).by(0)
+        }.not_to change(BulkSubmission, :count)
       end
     end
 
@@ -123,7 +123,7 @@ RSpec.describe BulkSubmissionFormsController, type: :request do
       it "does not create bulk_submission" do
         expect {
           post bulk_submission_forms_path, params: bulk_submission_form_params
-        }.to change(BulkSubmission, :count).by(0)
+        }.not_to change(BulkSubmission, :count)
       end
     end
 
@@ -142,7 +142,7 @@ RSpec.describe BulkSubmissionFormsController, type: :request do
       it "does not create bulk_submission" do
         expect {
           post bulk_submission_forms_path, params: bulk_submission_form_params
-        }.to change(BulkSubmission, :count).by(0)
+        }.not_to change(BulkSubmission, :count)
       end
     end
 
@@ -161,7 +161,7 @@ RSpec.describe BulkSubmissionFormsController, type: :request do
       it "does not create bulk_submission" do
         expect {
           post bulk_submission_forms_path, params: bulk_submission_form_params
-        }.to change(BulkSubmission, :count).by(0)
+        }.not_to change(BulkSubmission, :count)
       end
     end
   end
@@ -215,7 +215,7 @@ RSpec.describe BulkSubmissionFormsController, type: :request do
       it "does not create a new bulk_submission" do
         expect {
           patch bulk_submission_form_path(bulk_submission.id), params: bulk_submission_form_params
-        }.to change(BulkSubmission, :count).by(0)
+        }.not_to change(BulkSubmission, :count)
       end
 
       it "records the attempt to upload a file" do

--- a/spec/requests/bulk_submissions_controller_spec.rb
+++ b/spec/requests/bulk_submissions_controller_spec.rb
@@ -95,13 +95,13 @@ RSpec.describe BulkSubmissionsController, type: :request do
     it "does not destroy any bulk_submission" do
       expect {
         delete bulk_submission_path(bulk_submission.id)
-      }.to change(BulkSubmission, :count).by(0)
+      }.not_to change(BulkSubmission, :count)
     end
 
     it "does not destroy any bulk_submissions attachments" do
       expect {
         delete bulk_submission_path(bulk_submission.id)
-      }.to change(ActiveStorage::Attachment, :count).by(0)
+      }.not_to change(ActiveStorage::Attachment, :count)
     end
 
     it "discards the requested bulk_submission" do

--- a/spec/requests/bulk_submissions_controller_spec.rb
+++ b/spec/requests/bulk_submissions_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'system_helper'
 
-RSpec.describe BulkSubmissionsController, type: :request do
+RSpec.describe BulkSubmissionsController do
   before { sign_in user }
 
   let(:user) { create(:user) }

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe PagesController, type: :request do
+RSpec.describe PagesController do
   describe "#landing" do
     it "returns http success" do
       get "/"

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe StatusController do
       allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 1))
       allow(Sidekiq::RetrySet).to receive(:new).and_return(instance_double(Sidekiq::RetrySet, size: 0))
       allow(Sidekiq::DeadSet).to receive(:new).and_return(instance_double(Sidekiq::DeadSet, size: 0))
-      connection = instance_double("connection", info: {})
+      connection = instance_double(Sidekiq::RedisClientAdapter::CompatClient, info: {})
       allow(Sidekiq).to receive(:redis).and_yield(connection)
     end
 

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe StatusController do
       end
 
       it "returns JSON with app information" do
-        expect(JSON.parse(response.body)).to eq(expected_json)
+        expect(response.parsed_body).to eq(expected_json)
       end
     end
 
@@ -164,7 +164,7 @@ RSpec.describe StatusController do
       end
 
       it 'returns "Not Available"' do
-        expect(JSON.parse(response.body).values).to be_all("Not Available")
+        expect(response.parsed_body.values).to be_all("Not Available")
       end
     end
   end

--- a/spec/requests/users/mock_azure_controller_spec.rb
+++ b/spec/requests/users/mock_azure_controller_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe Users::MockAzureController, type: :request do
+RSpec.describe Users::MockAzureController do
   after do
     allow(Rails.configuration.x).to receive(:mock_azure).and_return(false)
     Rails.application.reload_routes!

--- a/spec/requests/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_controller_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe Users::OmniauthCallbacksController, type: :request do
+RSpec.describe Users::OmniauthCallbacksController do
   describe "POST users/auth/azure_ad/callback" do
     before do
       user

--- a/spec/services/bulk_submission_csv_parser_spec.rb
+++ b/spec/services/bulk_submission_csv_parser_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe BulkSubmissionCsvParser do
       end
 
       it "returns array of objects with expected attributes values" do
-        expect(call).to match_array([
-          have_attributes(
+        expect(call).to contain_exactly(have_attributes(
             period_start_date: "2023-01-01",
             period_start_at: Date.parse("2023-01-01"),
             period_end_date: "2023-03-31",
@@ -33,8 +32,7 @@ RSpec.describe BulkSubmissionCsvParser do
             date_of_birth: "2001-01-01",
             dob: Date.parse("2001-01-01"),
             nino: "JA123456D"
-          ),
-          have_attributes(
+          ), have_attributes(
             period_start_date: "2022-01-01",
             period_start_at: Date.parse("2022-01-01"),
             period_end_date: "2022-03-31",
@@ -44,8 +42,7 @@ RSpec.describe BulkSubmissionCsvParser do
             date_of_birth: "2002-01-01",
             dob: Date.parse("2002-01-01"),
             nino: "JA654321D"
-          ),
-        ])
+          ))
       end
     end
 

--- a/spec/services/bulk_submission_csv_parser_spec.rb
+++ b/spec/services/bulk_submission_csv_parser_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe BulkSubmissionCsvParser do
                date_of_birth: '', nino: '' }
 
       instance = record_struct.new(**args)
-      expect(instance).to be_kind_of(Struct)
+      expect(instance).to be_a(Struct)
       expect(instance).to respond_to(*args.keys)
       expect(instance).to respond_to(:period_start_at, :period_end_at, :dob)
     end

--- a/spec/services/bulk_submission_result_writer_service_spec.rb
+++ b/spec/services/bulk_submission_result_writer_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe BulkSubmissionResultWriterService do
 
         expected_content = <<~CSV
           "period_start_date","period_end_date","first_name","last_name","date_of_birth","nino","status","comment","tax_credit_annual_award_amount","clients_income_from_employment","clients_ni_contributions_from_employment","start_and_end_dates_for_employments","most_recent_payment_from_employment","clients_income_from_self_employment","clients_income_from_other_sources","most_recent_payment_from_other_sources","uc_one_data","uc_two_data"
-          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","0","0","","","","0","","[\n  {\n    "\"use_case\"": "\"use_case_one"\"\n  }\n]","[\n  {\n    "\"use_case\"": "\"use_case_two"\"\n  }\n]"
+          "2020-10-01","2020-12-31","John","Doe","2001-07-21","JA123456D","completed","","","0","0","","","","0","","[\n  {\n    ""use_case"": ""use_case_one""\n  }\n]","[\n  {\n    ""use_case"": ""use_case_two""\n  }\n]"
         CSV
 
         expect(bulk_submission.result_file.download).to eql(expected_content)

--- a/spec/services/bulk_submission_service_spec.rb
+++ b/spec/services/bulk_submission_service_spec.rb
@@ -46,8 +46,7 @@ RSpec.describe BulkSubmissionService do
 
         submissions = Submission.all.map {|e| e.attributes.with_indifferent_access }
 
-        expect(submissions).to match_array([
-          hash_including(
+        expect(submissions).to contain_exactly(hash_including(
             use_case: "one",
             period_start_at: Date.parse("2023-01-01"),
             period_end_at: Date.parse("2023-03-31"),
@@ -55,8 +54,7 @@ RSpec.describe BulkSubmissionService do
             last_name: "Bob",
             dob: Date.parse("2001-01-01"),
             nino: "JA123456D",
-          ),
-          hash_including(
+          ), hash_including(
             use_case: "two",
             period_start_at: Date.parse("2023-01-01"),
             period_end_at: Date.parse("2023-03-31"),
@@ -64,8 +62,7 @@ RSpec.describe BulkSubmissionService do
             last_name: "Bob",
             dob: Date.parse("2001-01-01"),
             nino: "JA123456D",
-          ),
-          hash_including(
+          ), hash_including(
             use_case: "one",
             period_start_at: Date.parse("2022-01-01"),
             period_end_at: Date.parse("2022-03-31"),
@@ -73,8 +70,7 @@ RSpec.describe BulkSubmissionService do
             last_name: "Boy",
             dob: Date.parse("2002-01-01"),
             nino: "JA654321D",
-          ),
-          hash_including(
+          ), hash_including(
             use_case: "two",
             period_start_at: Date.parse("2022-01-01"),
             period_end_at: Date.parse("2022-03-31"),
@@ -82,8 +78,7 @@ RSpec.describe BulkSubmissionService do
             last_name: "Boy",
             dob: Date.parse("2002-01-01"),
             nino: "JA654321D",
-          ),
-        ])
+          ))
       end
 
       it "updates bulk_submission status to \"prepared\"" do
@@ -153,8 +148,7 @@ RSpec.describe BulkSubmissionService do
 
         submissions = Submission.all.map {|e| e.attributes.with_indifferent_access }
 
-        expect(submissions).to match_array([
-          hash_including(
+        expect(submissions).to contain_exactly(hash_including(
             use_case: "one",
             period_start_at: Date.parse("2023-01-01"),
             period_end_at: Date.parse("2023-03-31"),
@@ -162,8 +156,7 @@ RSpec.describe BulkSubmissionService do
             last_name: "Bob",
             dob: Date.parse("2001-01-01"),
             nino: "JA123456D",
-          ),
-          hash_including(
+          ), hash_including(
             use_case: "two",
             period_start_at: Date.parse("2023-01-01"),
             period_end_at: Date.parse("2023-03-31"),
@@ -171,8 +164,7 @@ RSpec.describe BulkSubmissionService do
             last_name: "Bob",
             dob: Date.parse("2001-01-01"),
             nino: "JA123456D",
-          ),
-        ])
+          ))
       end
     end
 

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe MalwareScanner do
       let(:scan_result) do
         ["failed: No such file or directory. ERROR\n",
          "",
-         instance_double("process_status", exitstatus: 2, success?: false)]
+         instance_double(Process::Status, exitstatus: 2, success?: false)]
       end
 
       it "MalwareScanResult#scanner_working? returns false" do
@@ -102,7 +102,7 @@ RSpec.describe MalwareScanner do
       let(:scan_result) do
         ["whatever scan result",
          "",
-         instance_double("process_status", success?: true, exitstatus: 0)]
+         instance_double(Process::Status, success?: true, exitstatus: 0)]
        end
 
       it "MalwareScanResult#scan_result stores the result from clamav" do

--- a/spec/system/bulk_submission_form_dropzone_spec.rb
+++ b/spec/system/bulk_submission_form_dropzone_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe "sign in", type: :system, js: true do
+RSpec.describe "sign in", js: true do
   context "with unauthorised user" do
     it "redirects user back to landing page" do
       visit "/bulk_submission_forms/new"

--- a/spec/system/bulk_submission_form_non_js_spec.rb
+++ b/spec/system/bulk_submission_form_non_js_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe "sign in", type: :system do
+RSpec.describe "sign in" do
   context "with unauthorised user" do
     it "redirects user back to landing page" do
       visit "/bulk_submission_forms/new"

--- a/spec/system/bulk_submission_index_spec.rb
+++ b/spec/system/bulk_submission_index_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe "View bulk submission index page", type: :system do
+RSpec.describe "View bulk submission index page" do
   context "with unauthorised user" do
     it "redirects user back to landing page" do
       visit "/bulk_submissions"

--- a/spec/system/bulk_submission_show_spec.rb
+++ b/spec/system/bulk_submission_show_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe "View bulk submission show page", type: :system do
+RSpec.describe "View bulk submission show page" do
   context "with unauthorised user" do
     before { bulk_submission }
 

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe "sign in", type: :system do
+RSpec.describe "sign in" do
   context "with unauthorised user" do
     it "redirects user back to landing page" do
       visit "/"

--- a/spec/system/sign_out_spec.rb
+++ b/spec/system/sign_out_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe "sign out", type: :system do
+RSpec.describe "sign out" do
   let(:user) do
     User.create!(email: "Jim.Bob@example.co.uk",
                  first_name: "Jim",

--- a/spec/system/support/spec_helper.rb
+++ b/spec/system/support/spec_helper.rb
@@ -37,12 +37,12 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each, type: :system, js: true) do
+  config.before(:each, js: true, type: :system) do
     clear_downloads
     driven_by :headless_chrome
   end
 
-  config.after(:each, type: :system, js: true) do
+  config.after(:each, js: true, type: :system) do
     clear_downloads
   end
 

--- a/spec/system/view_profile_spec.rb
+++ b/spec/system/view_profile_spec.rb
@@ -1,6 +1,6 @@
 require "system_helper"
 
-RSpec.describe "view profile", type: :system do
+RSpec.describe "view profile" do
   let(:user) do
     User.create!(email: "Jim.Bob@example.co.uk",
                  first_name: "Jim",


### PR DESCRIPTION
## What
Enable new rubocop cops by default and fix or disable/exclude existing violations

Tidy and enforce the following new cops:

- Fix controller action order cop
- fix Style/RedundantStringEscape
- fix Style/RedundantConstantBase
- fix Style/FetchEnvVar
- fix FactoryBot/AssociationStyle
- fix Rails/DurationArithmetic
- fix RSpec/ChangeByZero
- fix RSpec/Rails/InferredSpecType
- fix RSpec/VerifiedDoubleReference
- fix Rails/RootPathnameMethods
- fix Lint/SymbolConversion
- fix RSpec/ClassCheck
- fix Rails/ResponseParsedBody
- fix RSpec/MatchArray
- fix RSpec/SortMetadata
- Exclude Lint/RedundantDirGlobSort for system helper
- disable Rails/ThreeStateBooleanColumn
- disable Lint/EmptyClass for patch
- fix Lint/DuplicateBranch

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
