### PR TITLE
AP-4288: Replace S3 long lived credentials with short lived IRSA service account 

### DIFF
--- a/.helm/assure-hmrc-data/templates/_envs.tpl
+++ b/.helm/assure-hmrc-data/templates/_envs.tpl
@@ -97,16 +97,6 @@ env:
       secretKeyRef:
         name: assure-hmrc-data-application-output
         key: hmrc_interface_secret
-  - name: S3_AWS_ACCESS_KEY_ID
-    valueFrom:
-      secretKeyRef:
-        name: s3-bucket-output
-        key: access_key_id
-  - name: S3_AWS_SECRET_ACCESS_KEY
-    valueFrom:
-      secretKeyRef:
-        name: s3-bucket-output
-        key: secret_access_key
   - name: S3_AWS_BUCKET_NAME
     valueFrom:
       secretKeyRef:

--- a/.helm/assure-hmrc-data/templates/deployment-web.yaml
+++ b/.helm/assure-hmrc-data/templates/deployment-web.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         releaseTime: {{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC"| quote }}
     spec:
+      serviceAccountName: "{{ .Values.service_account.name }}"
       containers:
         - name: clamav
           image: ghcr.io/ministryofjustice/hmpps-clamav:sha-0ae98e9

--- a/.helm/assure-hmrc-data/templates/deployment-worker.yaml
+++ b/.helm/assure-hmrc-data/templates/deployment-worker.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         {{- include "assure-hmrc-data.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: "{{ .Values.service_account.name }}"
       containers:
         - name: sidekiq-uc1
           image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'

--- a/.helm/assure-hmrc-data/values/production.yaml
+++ b/.helm/assure-hmrc-data/values/production.yaml
@@ -13,6 +13,9 @@ image:
   repository: null
   tag: null
 
+service_account:
+  name: laa-assure-hmrc-data-production-irsa
+
 service:
   type: ClusterIP
   port: 80

--- a/.helm/assure-hmrc-data/values/staging.yaml
+++ b/.helm/assure-hmrc-data/values/staging.yaml
@@ -13,6 +13,9 @@ image:
   repository: null
   tag: null
 
+service_account:
+  name: laa-assure-hmrc-data-staging-irsa
+
 service:
   type: ClusterIP
   port: 80

--- a/.helm/assure-hmrc-data/values/uat.yaml
+++ b/.helm/assure-hmrc-data/values/uat.yaml
@@ -13,6 +13,9 @@ image:
   repository: null
   tag: null
 
+service_account:
+  name: laa-assure-hmrc-data-uat-irsa
+
 service:
   type: ClusterIP
   port: 80

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,6 @@ local:
 
 amazon:
   service: S3
-  region: eu-west-2
   bucket: <%= ENV["S3_AWS_BUCKET_NAME"] %>
 
 # Remember not to checkin your GCS keyfile to a repository

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,8 +8,6 @@ local:
 
 amazon:
   service: S3
-  access_key_id: <%= ENV["S3_AWS_ACCESS_KEY_ID"] %>
-  secret_access_key: <%= ENV["S3_AWS_SECRET_ACCESS_KEY"] %>
   region: eu-west-2
   bucket: <%= ENV["S3_AWS_BUCKET_NAME"] %>
 


### PR DESCRIPTION
## What
Add IRSA service account and use instead of long lived credentials

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4288)

Switch to using IRSA policy for s3 bucket access.

Following instructions from [cloud-platform](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/accessing-aws-apis-and-resources-from-your-namespace.html#using-irsa-in-your-namespace) to
provide IAM role permissions to web and worker container pods.

See cloud-platform-environments irsa merged PRs
- https://github.com/ministryofjustice/cloud-platform-environments/pull/14282
- https://github.com/ministryofjustice/cloud-platform-environments/pull/14279
- https://github.com/ministryofjustice/cloud-platform-environments/pull/14194

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
