### PR TITLE
Bump ruby alpine from 3.17 to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 ###############################################################
 # base - dependencies required both at runtime and build time #
 ###############################################################
-FROM ruby:3.2.2-alpine3.17 as base
+FROM ruby:3.2.2-alpine3.18 AS base
 MAINTAINER LAA Apply for civil legal aid team
 
 # postgresql-dev: postgres driver and libraries
@@ -26,7 +26,7 @@ RUN apk add --update --no-cache tzdata && \
 ######################################################################
 # dependencies - build dependencies using build-time os dependencies #
 ######################################################################
-FROM base as dependencies
+FROM base AS dependencies
 
 # system dependencies required to build some gems
 # build-base: dependencies for bundle
@@ -62,7 +62,7 @@ RUN rm -rf log/* tmp/* /tmp && \
 ############################################
 # production - build and use runtime image #
 ############################################
-FROM base as production
+FROM base AS production
 
 # add non-root user and group with alpine first available uid, 1000
 ENV APPUID 1000


### PR DESCRIPTION
## What

Bump ruby alpine from 3.17 to [3.18](https://www.alpinelinux.org/posts/Alpine-3.18.0-released.html)


This aim to address the security vulnerable in golang

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
