### PR TITLE
Update Clamav install

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -73,7 +73,7 @@ jobs:
           yarn run stylelint
 
       - name: Install clamav client
-        run: sudo apt-get install -y --no-install-recommends clamdscan
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clamdscan
 
       - name: Run tests
         run: bundle exec rspec


### PR DESCRIPTION
## What

Update ClamAV install step in the test pipeline.  

The mirror had updated and the clamav package could not be located

Running `sudo apg-get update` first ensures the mirror will be updated and the package found

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
