### PR TITLE
Revert "build(deps): bump jsbundling-rails from 1.1.2 to 1.2.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
       rdoc
       reline (>= 0.3.8)
     jmespath (1.6.2)
-    jsbundling-rails (1.2.0)
+    jsbundling-rails (1.1.2)
       railties (>= 6.0.0)
     json (2.6.3)
     json-jwt (1.16.3)


### PR DESCRIPTION
Reverts ministryofjustice/laa-assure-hmrc-data#524

Reverting as [rspec failing](https://github.com/ministryofjustice/laa-assure-hmrc-data/actions/runs/6170809277/job/16748003665#step:12:1050), therefore blocking build and release.