### PR TITLE
AP-4456: Add `on: workflow_dispatch` triggering event

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -1,6 +1,7 @@
 name: CI and CD
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:


### PR DESCRIPTION

## What
Allow manual triggering of CI/CD pipeline

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4456)

Allow manual triggering of the CI/CD pipeline so that
amended kubernetes secrets can be picked up.

See [workflow_dispatch](https://docs.github.com/en/github-ae@latest/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) for details

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
