### PR TITLE
Rails-7.1: Use rails 7.1 config defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ require_relative '../lib/govuk_component'
 module LaaAssureHmrcData
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION


## What

Without this the querying of a users that have an encyrpted
attribute `encrypts :auth_subject_uid, deterministic: true`
was making  user unretrievable, causing a "User not found or
authorised" message on login.

Querying the User model directly causes:
```ruby
ActiveRecord::Encryption::Errors::Decryption: ActiveRecord::Encryption::Errors::Decryption> rescued during inspection
```

Accepting the 7.1 defaults avoids this error.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
