### PR TITLE
Fix: update DotEnv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem 'devise'
 gem "discard", "~> 1.3"
-gem 'dotenv-rails'
+gem 'dotenv'
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "jsbundling-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,10 +144,7 @@ GEM
     discard (1.3.0)
       activerecord (>= 4.2, < 8)
     docile (1.4.0)
-    dotenv (2.8.1)
-    dotenv-rails (2.8.1)
-      dotenv (= 2.8.1)
-      railties (>= 3.2)
+    dotenv (3.0.0)
     drb (2.2.0)
       ruby2_keywords
     email_validator (2.2.4)
@@ -259,8 +256,6 @@ GEM
     nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -539,12 +534,9 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  arm64-darwin-22
   arm64-darwin-23
-  x86_64-darwin-21
   x86_64-darwin-22
   x86_64-darwin-23
-  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3
@@ -554,7 +546,7 @@ DEPENDENCIES
   debug
   devise
   discard (~> 1.3)
-  dotenv-rails
+  dotenv
   erb_lint
   factory_bot_rails
   govuk-components

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-linux)
+      racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
@@ -537,6 +539,7 @@ PLATFORMS
   arm64-darwin-23
   x86_64-darwin-22
   x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3


### PR DESCRIPTION
## What

The gem has been update to 3.0.0 and started a deprecation process to replace dotenv-rails with a single-use dotenv gem

closes #876 

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
