### PR TITLE
Fix: Update k8s securityContext

### DIFF
--- a/.helm/assure-hmrc-data/templates/deployment-web.yaml
+++ b/.helm/assure-hmrc-data/templates/deployment-web.yaml
@@ -55,5 +55,12 @@ spec:
               path: /status
               port: http
             initialDelaySeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ "ALL" ]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/.helm/assure-hmrc-data/templates/deployment-worker.yaml
+++ b/.helm/assure-hmrc-data/templates/deployment-worker.yaml
@@ -34,6 +34,13 @@ spec:
             requests:
               cpu: 10m
               memory: 512Mi
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ "ALL" ]
           ports:
             - containerPort: 7433
           livenessProbe:


### PR DESCRIPTION



## What

Following a recent cluster upgrade, the cluster was adding these values to deploys and outputting a warning that they should be explicitly set.

This explicitly sets the required securityContext values in all pods to make deploys quieter and allow better surfacing of actual errors

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
