### PR TITLE
Chore: Remove syntax_tree gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,9 +42,6 @@ group :development do
   gem "prettier_print", require: false
   gem "rubocop-govuk", require: false
   gem "rubocop-performance", require: false
-  gem "syntax_tree", require: false
-  gem "syntax_tree-haml", require: false
-  gem "syntax_tree-rbs", require: false
   gem "web-console"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,10 +182,6 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 1)
-    haml (6.3.0)
-      temple (>= 0.8.2)
-      thor
-      tilt
     hashdiff (1.1.0)
     hashie (5.0.0)
     highline (3.0.1)
@@ -369,8 +365,6 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rbs (3.5.1)
-      logger
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redis-client (0.22.2)
@@ -483,17 +477,6 @@ GEM
       attr_required (>= 0.0.5)
       faraday (~> 2.0)
       faraday-follow_redirects
-    syntax_tree (6.2.0)
-      prettier_print (>= 1.2.0)
-    syntax_tree-haml (4.0.3)
-      haml (>= 5.2)
-      prettier_print (>= 1.2.1)
-      syntax_tree (>= 6.0.0)
-    syntax_tree-rbs (1.0.0)
-      prettier_print
-      rbs
-      syntax_tree (>= 2.0.1)
-    temple (0.10.3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.1)
@@ -578,9 +561,6 @@ DEPENDENCIES
   sidekiq
   sidekiq-scheduler
   simplecov
-  syntax_tree
-  syntax_tree-haml
-  syntax_tree-rbs
   tzinfo-data
   web-console
   webmock


### PR DESCRIPTION
## What

These have been in the application since the initial commit and I suspect that it was part of the original DFE template

They introduce a lot of dependencies so removing them will make a significant reduction to our dependency tree 🎉 

I have discussed with Joel and we are content that this will not impact the service, the gems are only in the development group so the removal will not affect the deployed service
>[!NOTE]
> I have logged in the the UAT environment and tested a variety of the test uploads and they have all completed successfully

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
