### PR TITLE
Fix: Update gemfile platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,7 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.8)
     minitest (5.25.4)
     msgpack (1.7.5)
     multi_xml (0.7.1)
@@ -250,11 +251,10 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.1-arm64-darwin)
+    nokogiri (1.18.1)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     nokogiri (1.18.1-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.18.1-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -519,11 +519,8 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
-  arm64-darwin-23
-  x86_64-darwin-22
-  x86_64-darwin-23
-  x86_64-darwin-24
-  x86_64-linux
+  ruby
+  x86_64-darwin
 
 DEPENDENCIES
   aws-sdk-s3


### PR DESCRIPTION
## What

The bundler dependabot passed tests but failed when building and deploying after merge.

There was an issue with the version of nokogiri not being available. This PR updates the platforms to match the working Apply deploy that included this nokogiri update

This PLATFORM list matches the platforms on Apply and should allow the build and deploy

It was updated using 
```sh
 bundle lock --add-platform ruby
 bundle lock --remove-platform x86_64-linux
```

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
