### PR TITLE
Chore: Amend /healthcheck endpoint to use database_exists?

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -25,9 +25,7 @@ class StatusController < ApplicationController
 private
 
   def database_alive?
-    ActiveRecord::Base.connection.active?
-  rescue PG::ConnectionBad
-    false
+    ActiveRecord::Base.connection.database_exists?
   end
 
   def redis_alive?

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe StatusController do
 
     context "when there is a problem with the database" do
       before do
-        allow(ActiveRecord::Base.connection).to receive(:active?).and_raise(PG::ConnectionBad, "error")
+        allow(ActiveRecord::Base.connection).to receive(:database_exists?).and_return(false)
         get "/healthcheck"
       end
 


### PR DESCRIPTION


## What
Amend /healthcheck endpoint to use database_exists?

[Identified while working on](https://dsdmoj.atlassian.net/browse/AP-5668)

Inline with hmrc-interface app, at least, and best
practice since rails 7.2 as `active?` may be false
due to lazy loaded connections.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
