### PR TITLE
Chore: Add build steps for dependabot PRs

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -86,7 +86,6 @@ jobs:
           retention-days: 7
 
   build:
-    if: github.actor != 'dependabot[bot]'
     needs: test
     runs-on: ubuntu-latest
     permissions:
@@ -106,6 +105,7 @@ jobs:
           ecr-repository: ${{ vars.ECR_REPOSITORY }}
 
   deploy-uat:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs: build
     environment: uat


### PR DESCRIPTION

## What

In December 2024 we saw a dependabot update where the tests passed but, when the PPR was merged, the build step failed because of a mis-match with the versions used.  Moving the conditional from the build step to the deploy-uat step should ensure that we test a proper build of the dependabot changes but do not deploy it unless needed

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
