### PR TITLE
Grant secrets read only permission to workflow  `build` job

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -91,6 +91,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      secrets: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

Dependabot does not have permissions to secrets.
Therefore causing the build step to fail, this grants read-only permissions to this step.

Explicitly add `secrets: read` permission to the `build` job.
This minimizes the exposure of secrets while still allowing necessary operations.


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
