### PR TITLE
Chore: revert build step

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -86,6 +86,7 @@ jobs:
           retention-days: 7
 
   build:
+    if: github.actor != 'dependabot[bot]'
     needs: test
     runs-on: ubuntu-latest
     permissions:
@@ -105,7 +106,6 @@ jobs:
           ecr-repository: ${{ vars.ECR_REPOSITORY }}
 
   deploy-uat:
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs: build
     environment: uat


### PR DESCRIPTION


## What

This was added to try and prevent build failures - see #1485 - when merging dependabot PRs but caused more pain as *every* PR then failed to build and had to be manually built and deployed anyway

Reverting to prevent pain, although we will need to consider how often these will fail to build and
deploy when we switch to GA full time on all repos!

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
