### PR TITLE
Chore: Split the dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,20 @@ updates:
       time: "03:00"
       timezone: Europe/London
     groups:
+      rubocop:
+        patterns:
+          - "rubocop*"
+      components:
+        patterns:
+          - "govuk-components"
+          - "view_component"
       bundler:
         patterns:
           - "*"
+        exclude-patterns:
+          - "rubocop*"
+          - "govuk-components"
+          - "view_component"
     open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## What

The view_component gems have been causing clashes, so split those out while we see if an upstream solution is offered

Also split out rubocop, this matches other services and prevents rubocop blocking wider updates

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
