### PR TITLE
Chore: Rename unprocessable_entity to unprocessable_content

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.9-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
@@ -305,6 +307,7 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-darwin)
     pg (1.6.2-x86_64-linux)
     pg (1.6.2-x86_64-linux-musl)
@@ -546,6 +549,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin
   x86_64-linux
   x86_64-linux-musl

--- a/app/controllers/bulk_submission_forms_controller.rb
+++ b/app/controllers/bulk_submission_forms_controller.rb
@@ -70,7 +70,7 @@ private
     if @form.save
       head :created, location: edit_bulk_submission_form_url(@form.bulk_submission.id)
     else
-      render json: { errors: @form.errors }, status: :unprocessable_entity
+      render json: { errors: @form.errors }, status: :unprocessable_content
     end
   end
 
@@ -101,7 +101,7 @@ private
     if @form.update
       head :accepted, location: edit_bulk_submission_form_url(@form.bulk_submission.id)
     else
-      render json: { errors: @form.errors }, status: :unprocessable_entity
+      render json: { errors: @form.errors }, status: :unprocessable_content
     end
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -7,8 +7,8 @@ class ErrorsController < ApplicationController
     render "not_found", status: :not_found
   end
 
-  def unprocessable_entity
-    render "unprocessable_entity", status: :unprocessable_content
+  def unprocessable_content
+    render "unprocessable_content", status: :unprocessable_content
   end
 
   def too_many_requests

--- a/app/views/errors/unprocessable_content.html.erb
+++ b/app/views/errors/unprocessable_content.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('.unprocessable_entity') %></h1>
+    <h1 class="govuk-heading-l"><%= t('.unprocessable_content') %></h1>
 
     <p class="govuk-body"><%= t('.try_again_later') %></p>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -323,7 +323,7 @@ Devise.setup do |config|
   # apps is `200 OK` and `302 Found respectively`, but new apps are generated with
   # these new defaults that match Hotwire/Turbo behavior.
   # Note: These might become the new default in future versions of Devise.
-  config.responder.error_status = :unprocessable_entity
+  config.responder.error_status = :unprocessable_content
   config.responder.redirect_status = :see_other
 
   # ==> Configuration for :registerable

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -18,8 +18,8 @@ en:
       page_title: Sorry, there’s a problem with the service
       too_many_requests: Sorry, there’s a problem with the service
       try_again_later: Try again later.
-    unprocessable_entity:
+    unprocessable_content:
       error_continues_html: 'If you continue to see this error contact the "%{service}" team: <a class="govuk-link" href="mailto:%{email}">%{email}</a>.'
       page_title: Sorry, there’s a problem with the service
       try_again_later: Try again later.
-      unprocessable_entity: Sorry, there’s a problem with the service
+      unprocessable_content: Sorry, there’s a problem with the service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
 
   scope via: :all do
     get "/404", to: "errors#not_found"
-    get "/422", to: "errors#unprocessable_entity"
+    get "/422", to: "errors#unprocessable_content"
     get "/429", to: "errors#too_many_requests"
     get "/500", to: "errors#internal_server_error"
   end

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ErrorsController do
     end
   end
 
-  describe "#unprocessable_entity" do
+  describe "#unprocessable_content" do
     before { get "/422" }
 
     it "returns status 422 and unprocessable entity content", :aggregate_failures do


### PR DESCRIPTION
## What
Rename unprocessable_entity to unprocessable_content

To handle the deprecation warnings

```
.rvm/gems/ruby-3.4.5/gems/actionpack-8.0.2.1/lib/action_controller/metal/rendering.rb:235: warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
```


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
