### PR TITLE
AP-6241: Allow custom errors on main branch only

### DIFF
--- a/.github/actions/deploy_branch/action.yml
+++ b/.github/actions/deploy_branch/action.yml
@@ -77,6 +77,7 @@ runs:
         ingress_name="assure-hmrc-data"
         release_host="$RELEASE_NAME-$KUBE_NAMESPACE.cloud-platform.service.justice.gov.uk"
         identifier="$RELEASE_NAME-$ingress_name-$KUBE_NAMESPACE-green"
+        is_main=$([[ $RELEASE_NAME == "main" ]] && echo true || echo false)
 
         echo "Deploying commit: $GIT_SHA under release name: '$RELEASE_NAME' to '$release_host'..."
 
@@ -89,7 +90,7 @@ runs:
           --set branch_builder.database_name=$RELEASE_NAME \
           --set branch_builder.omniauth_azure_redirect_uri="https://${release_host}/users/auth/azure_ad/callback" \
           --set sidekiq.queue_name="-$RELEASE_NAME" \
-          --set customErrorService.enabled=false \
+          --set customErrorService.enabled=$is_main \
           --values ${VALUES_FILE} \
           --install \
           --wait


### PR DESCRIPTION
## What
Allow custom errors on main branch only

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6241)

The custom error config map, service and pod/deployment
are shared by all branches in the UAT namespace. They need to
be deployed to UAT on merge to main or their existing components are 
destroyed, but they should only be deployed against main.

## Testing

```
  env:
     ...
    RELEASE_NAME: ap-6241-allow-custom-errors-on
is_main variable value is: false <-- TESTING
```
## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
