### PR TITLE
Revert "AP-6260: Ignore npm based updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,6 @@ updates:
       day: thursday
       time: "03:15"
       timezone: Europe/London
-    ignore:
-      - dependency-name: "*"
     groups:
       npm:
         patterns:


### PR DESCRIPTION
Reverts ministryofjustice/laa-assure-hmrc-data#1622 once shai-hulud attack is deemed to be over and npm cleaned.