### PR TITLE
AP-6260: Mitigations against supply chain attack

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install packages with yarn
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Precompile assets
         run: bin/rails assets:precompile

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ") && \
 
 # install npm packages
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --check-files --ignore-scripts
+RUN NODE_ENV=production yarn install --prod --frozen-lockfile --check-files --ignore-scripts
 
 # cleanup to save space in the image
 RUN rm -rf log/* tmp/* /tmp && \

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -28,7 +28,7 @@ bin/setup
 
 - run the application
 ```shell
-yarn install --frozen-lockfile
+yarn install --frozen-lockfile --ignore-scripts
 # THEN
 bin/dev
 # OR


### PR DESCRIPTION
## What
Ignore scripts and use frozen lockfile

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6260)

Some mitigations against Shai-Hulud and supply chain attacks.

Ignore scripts run by pre, postinstall sections of package.json and only use packages in the yarn.lock - don’t generate a yarn.lock lockfile and fail if an update is needed - to install JS dependencies.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
