### PR TITLE
AP-6260: Remove npm from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,17 +30,15 @@ updates:
           - "govuk-components"
           - "view_component"
     open-pull-requests-limit: 10
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: thursday
-      time: "03:15"
-      timezone: Europe/London
-    ignore:
-      - dependency-name: "*"
-    groups:
-      npm:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 10
+  # - package-ecosystem: "npm"
+  #   directory: "/"
+  #   schedule:
+  #     interval: weekly
+  #     day: thursday
+  #     time: "03:15"
+  #     timezone: Europe/London
+  #   groups:
+  #     npm:
+  #       patterns:
+  #         - "*"
+  #   open-pull-requests-limit: 10


### PR DESCRIPTION
## What
Remove npm from dependabot

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6260)

Until threat from shai-hulud has abated.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
