### PR TITLE
AP-6785: Allow ping endpoint to be accessed out of hours

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,6 +1,8 @@
 class StatusController < ApplicationController
   skip_before_action :authenticate_user!, :verify_authenticity_token
 
+  skip_before_action :out_of_hours_redirect, only: [:ping]
+
   def status
     checks = {
       database: database_alive?,

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -128,6 +128,20 @@ RSpec.describe StatusController do
         expect(response.body).to eq(expected_response)
       end
     end
+
+    context "when out of hours" do
+      before do
+        get "/healthcheck"
+      end
+
+      around do |example|
+        travel_to(Rails.configuration.x.business_hours.end.to_time + 1.minute) { example.run }
+      end
+
+      it "redirects to out of hours page" do
+        expect(response).to render_template("pages/service_out_of_hours")
+      end
+    end
   end
 
   describe "#ping" do
@@ -165,6 +179,27 @@ RSpec.describe StatusController do
 
       it 'returns "Not Available"' do
         expect(response.parsed_body.values).to be_all("Not Available")
+      end
+    end
+
+    context "when out of hours" do
+      before do
+        allow(Rails.configuration.x.status).to receive_messages(build_date: "testing",
+                                                                build_tag: "testing",
+                                                                git_commit: "testing",
+                                                                app_branch: "testing")
+
+        get "/ping"
+      end
+
+      around do |example|
+        travel_to(Rails.configuration.x.business_hours.end.to_time + 1.minute) { example.run }
+      end
+
+      it "still returns HTTP success and expected body" do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include(/service is available daily/)
+        expect(response.parsed_body.values).to be_all("testing")
       end
     end
   end


### PR DESCRIPTION


## What
Allow ping endpoint to be accessed out of hours

[Follow up on story](https://dsdmoj.atlassian.net/browse/AP-6785)

Currently pingdom checks the /ping endpoint every 1 minute,
but this is blocked out of hours by the out_of_hours_redirect
before_action in ApplicationController. This means that the service is
alerting as down during out of hours periods, which is not ideal and unecessary
noise.


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
