### PR TITLE
Chore: Update SHA tagging

### DIFF
--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Delete UAT release
         id: delete_uat
-        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.1.0
+        uses: ministryofjustice/laa-civil-apply-delete-uat-release@23e404138cfb4442ec62d8a13dfccc5355231b17 # v1.1.0
         with:
           k8s_cluster: ${{ secrets.KUBE_UAT_CLUSTER }}
           k8s_cluster_cert: ${{ secrets.KUBE_UAT_CERT }}


### PR DESCRIPTION
## What

Spotted a warning that the delete uat release workflow did not use SHA tagging

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
