### PR TITLE
AP-6790: Pin remaining GHAS actions to specific versions

### DIFF
--- a/.github/actions/build_and_push/action.yml
+++ b/.github/actions/build_and_push/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Docker login to ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a #v2.1.3
       with:
         mask-password: 'true'
 

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Docker login to ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a #v2.1.3
       with:
         mask-password: 'true'
 

--- a/.github/actions/deploy_branch/action.yml
+++ b/.github/actions/deploy_branch/action.yml
@@ -60,7 +60,7 @@ runs:
 
     - name: Docker login to ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a #v2.1.3
       with:
         mask-password: 'true'
 

--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   brakeman:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/brakeman.yml@main
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/brakeman.yml@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main on 15/04/2026
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   scan-docker-image:
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/snyk.yml@main
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/snyk.yml@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main on 15/04/2026
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: JS package cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -83,7 +83,7 @@ jobs:
         run: bundle exec rspec
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage


### PR DESCRIPTION

## What
Pin remaining github actions

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6790)

Security best practice.

You can find all unpinned actions with 

```sh
 grep -RnE --exclude-dir=node_modules --include="*.yml" --include="*.yaml" 'uses:\s*[^ ]+@(main|master|v[0-9][^ ]*)' .
```

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
