### PR TITLE
AP-6818: Github actions permissions audit

### DIFF
--- a/.github/workflows/clean-gh-actions-cache.yml
+++ b/.github/workflows/clean-gh-actions-cache.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
       actions: write
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 #v1 Beta 9
       - name: Clear GitHub Actions cache
         run: |
           gh extension install actions/gh-actions-cache

--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -11,6 +11,7 @@ jobs:
   delete_uat_job:
     runs-on: ubuntu-latest
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 #v1 Beta 9
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Delete UAT release
         id: delete_uat

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -16,9 +16,6 @@ permissions: {}
 jobs:
   test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
     env:
       RACK_ENV: test
       RAILS_ENV: test
@@ -95,7 +92,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
 
     steps:
       - name: Checkout
@@ -115,7 +111,6 @@ jobs:
     environment: uat
     permissions:
       id-token: write
-      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6818)

Github actions permissions audit:

- Implement changes recommended in actions-permissions audit for the test and build steps in the ci workflow.
- Add the actions-permissions step to the clean-gh-actions-cache workflow and delete-uat-release workflow as well, as these are only run when a PR is closed.

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
