### PR TITLE
Chore: Fix delete UAT release workflow permissions

### DIFF
--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   delete_uat_job:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Delete UAT release


### PR DESCRIPTION


## What
Testing

Currently the jobs fails with a "Minimal required permissions" error or waarning
but this may not be the cause so just eliminting the possibility


## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
