### PR TITLE
AP-7125: Add checkout permissions and GHA tweaks

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -13,4 +13,5 @@ jobs:
   brakeman:
     uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/brakeman.yml@a0bd8225ca8cc96e57a19223ce21f2ce7230833c # main as of 24/06/2026
     permissions:
+      contents: read # for actions/checkout
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -12,7 +12,9 @@ jobs:
   delete_uat_job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #--v7.0.0
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #--v7.0.0
+
       - name: Delete UAT release
         id: delete_uat
         uses: ministryofjustice/laa-civil-apply-delete-uat-release@23e404138cfb4442ec62d8a13dfccc5355231b17 # v1.1.0

--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -5,7 +5,8 @@ on:
     types:
       - closed
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   delete_uat_job:

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -11,7 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION

## What
Add checkout permissions and GHA tweaks

[Link to story](https://dsdmoj.atlassian.net/browse/AP-7125)

- **AP-7125: Add contents read permission to workflows**
- **AP-7125: allow brakeman resuable action to read repo even if private**
- **AP-7125: Provide explicit name for checkout step**

## Checklist

Before you ask people to review this PR:

- Tests and linters should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
